### PR TITLE
Build both netmaker and netclient docker images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,40 +6,100 @@ on:
       tag:
         description: 'docker tag'
         required: true
+  push:
+    tags:
+      - 'v*'
   pull_request:
     branches:
-      - 'test'
       - 'master'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hakeee/netmaker
+  IMAGE_NAME_CLIENT: hakeee/netclient
+
 jobs:
-  docker:
+  build-and-push-netclient:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Set tag
-        run: |
-            if [[ -n "${{ github.event.inputs.tag }}" ]]; then
-              TAG=${{ github.event.inputs.tag }}
-            elif [[ "${{ github.base_ref }}" == 'master' ]]; then
-              TAG="latest"
-            else
-              TAG="${{ github.base_ref }}"
-            fi
-            echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_CLIENT }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push latest
+
+      - name: Build and push latest client
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: gravitl/netmaker:${{ env.TAG }}
+          file: ./Dockerfile-netclient
+          platforms: linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-netmaker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push latest server
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set tag
+        run: |
+            if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+              TAG=${{ github.event.inputs.tag }}
+            elif [[ "${{ github.base_ref }}" == 'master' ]]; then
+              TAG="latest"
+            else
+              TAG="${{ github.base_ref }}"
+            fi
+            echo "TAG=${TAG}" >> $GITHUB_ENV
+            
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -45,6 +56,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ env.TAG }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -71,6 +83,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set tag
+        run: |
+            if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+              TAG=${{ github.event.inputs.tag }}
+            elif [[ "${{ github.base_ref }}" == 'master' ]]; then
+              TAG="latest"
+            else
+              TAG="${{ github.base_ref }}"
+            fi
+            echo "TAG=${TAG}" >> $GITHUB_ENV
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -88,6 +111,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ env.TAG }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,8 +15,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: hakeee/netmaker
-  IMAGE_NAME_CLIENT: hakeee/netclient
+  IMAGE_NAME: gravitl/netmaker
+  IMAGE_NAME_CLIENT: gravitl/netclient
 
 jobs:
   build-and-push-netclient:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ WORKDIR /app
 
 ENV GO111MODULE=auto
 
-RUN GOARCH=amd64 CGO_ENABLED=1 GOOS=linux go build -ldflags="-w -s" -o app main.go
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-w -s" -o app main.go
 
 WORKDIR /app/netclient
 
 ENV GO111MODULE=auto
 
-RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o netclient main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o netclient main.go
 
 #second stage
 

--- a/Dockerfile-netclient
+++ b/Dockerfile-netclient
@@ -1,26 +1,31 @@
-#first stage - builder
+FROM golang:alpine3.14 AS builder
 
-FROM golang:latest as builder
+# Install wget
+RUN apk add --no-cache git
 
-COPY . /app
+WORKDIR /app
+# Install go dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
 WORKDIR /app/netclient
+COPY . /app
 
 ENV GO111MODULE=auto
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o netclient main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o netclient main.go
 
-#second stage
+FROM crazymax/alpine-s6:3.14-2.2.0.3
 
-FROM debian:latest
+VOLUME /etc/netclient
+RUN apk add --no-cache --update wireguard-tools openssh
+COPY --from=builder /app/netclient/netclient /bin/netclient
+COPY ./netclient/docker-files/cont-init.d /etc/cont-init.d
+COPY ./netclient/docker-files/services.d /etc/services.d
+RUN ln -s /bin/true /bin/systemctl \
+    && ln -s /bin/true /bin/resolvectl \
+    && mkdir -p /etc/systemd/system/ \
+    && mkdir -p /etc/netclient/ \
+    && cp /bin/netclient /etc/netclient/netclient
 
-RUN apt-get update && apt-get -y install systemd procps
-
-WORKDIR /root/
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-COPY --from=builder /app/netclient/netclient .
-
-CMD ["./netclient"]
-
+ENTRYPOINT ["/init"]

--- a/Dockerfile-netclient
+++ b/Dockerfile-netclient
@@ -18,14 +18,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o netclient main.go
 FROM crazymax/alpine-s6:3.14-2.2.0.3
 
 VOLUME /etc/netclient
-RUN apk add --no-cache --update wireguard-tools openssh
+RUN apk add --no-cache --update wireguard-tools
 COPY --from=builder /app/netclient/netclient /bin/netclient
 COPY ./netclient/docker-files/cont-init.d /etc/cont-init.d
+COPY ./netclient/docker-files/fix-attrs.d /etc/fix-attrs.d
 COPY ./netclient/docker-files/services.d /etc/services.d
-RUN ln -s /bin/true /bin/systemctl \
-    && ln -s /bin/true /bin/resolvectl \
-    && mkdir -p /etc/systemd/system/ \
-    && mkdir -p /etc/netclient/ \
-    && cp /bin/netclient /etc/netclient/netclient
+COPY ./netclient/docker-files/bin/resolvectl /bin/resolvectl
 
 ENTRYPOINT ["/init"]

--- a/compose/docker-compose.netclient-sample.yml
+++ b/compose/docker-compose.netclient-sample.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  netclient:
+    image: ghcr.io/hakeee/netclient
+    container_name: netmaker_sample_netclient
+    mac_address: 02:42:ac:11:65:57
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    volumes:
+      - /lib/modules:/lib/modules
+      - ./netclient:/etc/netclient # Where netclient configs will be stored, not required
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    environment:
+      - "NET_TOKEN=" # Required on first start
+      #- "CUSTOM_DNS=8.8.8.8 1.1.1.1" # Fallbacks to dockerdns 127.0.0.11
+
+  # Nginx exposes the service on port 80.
+  # This service will be reachable on the ip netclient gets without usung expose or port mapping.
+  # To make it available on the host then netclient need to export a port that is mapped to 80 
+  hello:
+    image: nginxdemos/hello
+    network_mode: service:netclient
+    depends_on:
+      - netclient

--- a/compose/docker-compose.netclient-sample.yml
+++ b/compose/docker-compose.netclient-sample.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   netclient:
-    image: ghcr.io/hakeee/netclient
+    image: ghcr.io/gravitl/netclient
     container_name: netmaker_sample_netclient
     mac_address: 02:42:ac:11:65:57
     cap_add:

--- a/netclient/docker-files/bin/resolvectl
+++ b/netclient/docker-files/bin/resolvectl
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv sh
+
+if [ "$1" = "dns" ]; then
+  echo "nameserver $3 ${CUSTOM_DNS:-127.0.0.11}" | resolvconf -a "$2"
+fi

--- a/netclient/docker-files/cont-init.d/01-join
+++ b/netclient/docker-files/cont-init.d/01-join
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv sh
+if ! stat /etc/netclient/netconfig-* > /dev/null 2>&1; then
+  netclient join --dnson=no --daemon=off -t "$NET_TOKEN"
+fi

--- a/netclient/docker-files/cont-init.d/02-pull
+++ b/netclient/docker-files/cont-init.d/02-pull
@@ -1,0 +1,2 @@
+#!/usr/bin/with-contenv sh
+netclient pull -n "$(ls /etc/netclient | grep netconfig- | cut -c 11-)"

--- a/netclient/docker-files/fix-attrs.d/01-resolvectl
+++ b/netclient/docker-files/fix-attrs.d/01-resolvectl
@@ -1,0 +1,1 @@
+/bin/resolvectl false root,0:0 0777 0777

--- a/netclient/docker-files/services.d/checkin/run
+++ b/netclient/docker-files/services.d/checkin/run
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv sh
+NET_NAME="$(ls /etc/netclient | grep netconfig- | cut -c 11-)"
+while :	
+do
+        netclient checkin -n "${NET_NAME}"
+        sleep 30
+done


### PR DESCRIPTION
## Builds
Builds both netmaker and netclient with manifest for platforms : 
* linux/amd64
*  linux/arm64
*  linux/arm/v6
*  linux/arm/v7

### Tags
Auto builds for:
* All git tags starting with v, example v0.0.1
* Pull requests to master
* Manually triggered with required tag name 

Branch name is always added as a tag to the image

## Netclient

Environment:
* NET_TOKEN is required
* CUSTOM_DNS is optional but will replace dockers dns service (127.0.0.11)


### Changes to PR
To use dockerhub instead, then changes should be made to change registry env in the build file and change credentials