### PR TITLE
Added Volume to netmaker-backend container spec

### DIFF
--- a/kube/netmaker-template.yaml
+++ b/kube/netmaker-template.yaml
@@ -65,6 +65,9 @@ spec:
           value: "Kubernetes"
         - name: CORS_ALLOWED_ORIGIN
           value: "*"
+        volumeMounts:
+        - name: nm-pvc
+          mountPath: /root/config/dnsconfig
       - name: rqlite
         image: rqlite/rqlite
         ports:


### PR DESCRIPTION
The volume for the DNS config was not included in the netmaker-backend container spec.  This caused the coredns container to continually fail.