### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+# Basic dependabot.yml file with minimum configuration for gomod.
+
+version: 2
+updates:
+  # Enable version updates for go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds support for running dependabot against `gomod` on a daily basis. I ran this on a fork and it created 5 Pull Requests for dependencies that are outdated. 

Small note: I noticed the current github workflow for this project, is trying to Push all images to `DockerHub` was that intended? Usually projects only push the image if it's NOT a Pull-Request.

![image](https://user-images.githubusercontent.com/835733/136207980-39f522ad-34c5-491c-8426-5ae83a3c0c53.png)
