### PR TITLE
[#349] Use HTTPS for ip checks

### DIFF
--- a/netclient/ncutils/netclientutils.go
+++ b/netclient/ncutils/netclientutils.go
@@ -110,7 +110,7 @@ func GenPass() string {
 // GetPublicIP - gets public ip
 func GetPublicIP() (string, error) {
 
-	iplist := []string{"http://ip.client.gravitl.com", "https://ifconfig.me", "http://api.ipify.org", "http://ipinfo.io/ip"}
+	iplist := []string{"http://ip.client.gravitl.com", "https://ifconfig.me", "https://api.ipify.org", "https://ipinfo.io/ip"}
 	endpoint := ""
 	var err error
 	for _, ipserver := range iplist {


### PR DESCRIPTION
This uses HTTPS for all external IP Checkers that support it.