### PR TITLE
Feat/change default hostname

### DIFF
--- a/netclient/main.go
+++ b/netclient/main.go
@@ -26,6 +26,11 @@ func main() {
 	app.Usage = "Netmaker's netclient agent and CLI. Used to perform interactions with Netmaker server and set local WireGuard config."
 	app.Version = "v0.8.3"
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = ""
+	}
+
 	cliFlags := []cli.Flag{
 		&cli.StringFlag{
 			Name:    "network",
@@ -91,7 +96,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "name",
 			EnvVars: []string{"NETCLIENT_NAME"},
-			Value:   "",
+			Value:   hostname,
 			Usage:   "Identifiable name for machine within Netmaker network.",
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
This PR proposes a solution for the issue #352 

The server may want to refuse the join operation if the hostname already exits in the network.