### PR TITLE
Update nm-quick.sh for parameters domain= and email=

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -64,9 +64,8 @@ arg2=$( echo $2 | awk -F"domain=" '{print $2}')
 if [ -n "$arg1" ]; then
   echo "Parameter NETMAKER_BASE_DOMAIN is $arg1"
   NETMAKER_BASE_DOMAIN=$arg1
-fi
 
-if [ -n "$arg2" ]; then
+elif [ -n "$arg2" ]; then
   echo "Parameter NETMAKER_BASE_DOMAIN is $arg2"
   NETMAKER_BASE_DOMAIN=$arg2
 fi
@@ -77,9 +76,8 @@ arg2=$( echo $2 | awk -F"email=" '{print $2}')
 if [ -n "$arg1" ]; then
   echo "Parameter EMAIL is $arg1"
   EMAIL=$arg1
-fi
 
-if [ -n "$arg2" ]; then
+elif [ -n "$arg2" ]; then
   echo "Parameter EMAIL is $arg2"
   EMAIL=$arg2
 fi


### PR DESCRIPTION
These parameters can be used:
domain= and/or email=

**Example**:
sudo wget -qO - https://raw.githubusercontent.com/gravitl/netmaker/develop/scripts/nm-quick.sh | bash -s domain=mynetmaker.domain.com email=example@email.com

Because of "bash -s" further flags like -d or -e are not possible.
This is why we now check on $1 and $2 parameters.
You can set domain= or email= or both. Order does not matter.
email= and domain= would work too.