### PR TITLE
Prepend a 'v' when version is not 'latest' and lacks a leading 'v'.

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -8,6 +8,7 @@ fi
 
 [ -z "$KEY" ] && KEY=nokey;
 [ -z "$VERSION" ] && echo "no \$VERSION provided, fallback to latest" && VERSION=latest;
+[ "latest" != "$VERSION" ] && [ "v" != `echo $VERSION | cut -c1` ] && VERSION="v$VERSION"
 
 dist=netclient
 


### PR DESCRIPTION
This PR addresses #403 with respect to the VERSION not matching the github version tags.


Sample executions (with manual exit after printing version) to show how this works:

```
~/code/netmaker/scripts$ sudo VERSION=v0.8.4 ./netclient-install.sh
OS Version = Linux
Netclient Version = v0.8.4
~/code/netmaker/scripts$ sudo VERSION=0.8.4 ./netclient-install.sh
OS Version = Linux
Netclient Version = v0.8.4
~/code/netmaker/scripts$ sudo VERSION=latest ./netclient-install.sh
OS Version = Linux
Netclient Version = latest
```