### PR TITLE
Fix/host name issue

### DIFF
--- a/netclient/main.go
+++ b/netclient/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/gravitl/netmaker/netclient/command"
@@ -30,6 +31,7 @@ func main() {
 	if err != nil {
 		hostname = ""
 	}
+	hostname = strings.Split(hostname, ".")[0]
 
 	cliFlags := []cli.Flag{
 		&cli.StringFlag{

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -51,6 +51,7 @@ set -e
 
 [ -z "$KEY" ] && KEY=nokey;
 [ -z "$VERSION" ] && echo "no \$VERSION provided, fallback to latest" && VERSION=latest;
+[ -z "$NAME" ] && NAME="";
 
 dist=netclient
 
@@ -94,5 +95,5 @@ echo "Binary = $dist"
 
 wget -nv -O netclient https://github.com/gravitl/netmaker/releases/download/$VERSION/$dist
 chmod +x netclient
-sudo ./netclient join -t $KEY
+sudo ./netclient join -t $KEY --name $NAME
 rm -f netclient


### PR DESCRIPTION
This PR should solve #405

As default (no hostname specified), we split the hostname with the char "." given. 

We also provide a NAME variable in the installation script that eases hostname custom setup