### PR TITLE
armv7l fix

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -78,6 +78,9 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
 			aarch64)
                                 dist=netclient-arm64
 			;;
+			armv7l)
+                                dist=netclient-armv7
+			;;
 			arm*)
 				dist=netclient-$CPU_ARCH
             		;;


### PR DESCRIPTION
Pi Zero 2 or some Pi 3 will have armv7l. They need armv7.
uname -m
armv7l

it printed a 404 error because thre is no armv7l file