### PR TITLE
Docker compose remove host binding for Caddy

### DIFF
--- a/compose/docker-compose.caddy.yml
+++ b/compose/docker-compose.caddy.yml
@@ -16,6 +16,7 @@ services:
       - NET_ADMIN
       - SYS_ADMIN
     restart: always
+    network_mode: host
     privileged: true
     environment:
       SERVER_HOST: "SERVER_PUBLIC_IP"

--- a/compose/docker-compose.caddy.yml
+++ b/compose/docker-compose.caddy.yml
@@ -43,8 +43,6 @@ services:
     image: gravitl/netmaker-ui:v0.8.5
     links:
       - "netmaker:api"
-    ports:
-      - "8082:80"
     environment:
       BACKEND_URL: "https://api.NETMAKER_BASE_DOMAIN"
     restart: always

--- a/compose/docker-compose.caddy.yml
+++ b/compose/docker-compose.caddy.yml
@@ -35,8 +35,6 @@ services:
       CORS_ALLOWED_ORIGIN: "*"
       DATABASE: "sqlite"
       NODE_ID: "netmaker-server-1"
-    ports:
-      - "51821-51830:51821-51830/udp"
   netmaker-ui:
     container_name: netmaker-ui
     depends_on:

--- a/compose/docker-compose.caddy.yml
+++ b/compose/docker-compose.caddy.yml
@@ -16,7 +16,6 @@ services:
       - NET_ADMIN
       - SYS_ADMIN
     restart: always
-    network_mode: host
     privileged: true
     environment:
       SERVER_HOST: "SERVER_PUBLIC_IP"
@@ -37,8 +36,6 @@ services:
       NODE_ID: "netmaker-server-1"
     ports:
       - "51821-51830:51821-51830/udp"
-      - "8081:8081"
-      - "50051:50051"
   netmaker-ui:
     container_name: netmaker-ui
     depends_on:
@@ -67,7 +64,14 @@ services:
     image: caddy:latest
     container_name: caddy
     restart: unless-stopped
-    network_mode: host # Wants ports 80 and 443!
+    links:
+      - netmaker:api
+      - netmaker-ui:ui
+    ports:
+      - 80:80
+      - 443:443
+    cap_add:
+      - cap_net_bind_service
     volumes:
       - /root/Caddyfile:/etc/caddy/Caddyfile
       # - $PWD/site:/srv # you could also serve a static site in site folder

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -5,15 +5,15 @@
 
 # Dashboard
 https://dashboard.NETMAKER_BASE_DOMAIN {
-    reverse_proxy http://127.0.0.1:8082
+    reverse_proxy http://ui:80
 }
 
 # API
 https://api.NETMAKER_BASE_DOMAIN {
-    reverse_proxy http://127.0.0.1:8081
+    reverse_proxy http://api:8081
 }
 
 # gRPC
 https://grpc.NETMAKER_BASE_DOMAIN {
-    reverse_proxy h2c://127.0.0.1:50051
+    reverse_proxy h2c://api:50051
 }


### PR DESCRIPTION
Hi,

It's better to avoid using `network_mode: host` as much as possible.
If you need it for binding privliedge port like `80` and `443` then it's better to use `capabilities: cap_net_bind_service`.

I'm currently running this config without any issue, caddy is listening on the right ports and we can remove unneeded port bindings by relying on the links