### PR TITLE
Update netclient-install.sh

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -105,5 +105,5 @@ else
 	wget -nv -O netclient https://github.com/gravitl/netmaker/releases/download/latest/$dist
 fi
 chmod +x netclient
-sudo ./netclient join -t $KEY
+./netclient join -t $KEY
 rm -f netclient


### PR DESCRIPTION
Remove sudo command from line 108

The script already checks to make sure it's being run as root, so sudo is superfluous here, and causes minimal Debian installs to fail since sudo is not included in base Debian.