### PR TITLE
Update install script: netclient-armv7 to netclient-arm7

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -105,7 +105,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
                                 dist=netclient-arm64
 			;;
 			armv7l)
-                                dist=netclient-armv7
+                                dist=netclient-arm7
 			;;
 			arm*)
 				dist=netclient-$CPU_ARCH


### PR DESCRIPTION
Wrong url generated by the script. The file to download is ...-arm7 and not ...-armv7