### PR TITLE
build: upgrade to Go 1.17

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Build
         run: |

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -1,4 +1,4 @@
-name: Build artifacts for deployment testing 
+name: Build artifacts for deployment testing
 
 on:
     push:
@@ -34,6 +34,10 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
+            - name: Setup Go
+              uses: actions/setup-go@v2
+              with:
+                go-version: 1.17
             - name: build client
               run: |
                 cd netclient
@@ -48,4 +52,4 @@ jobs:
             #  run: |
             #      curl -X POST https://api.github.com/mattkasun/terraform-test/dispatches \
             #      -H 'Accept: application/vnd.github.everest-preview+json' \
-            #      -u ${{ secrets.ACCESS_TOKEN }} 
+            #      -u ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - name: run tests
         run: |
             go test -p 1 ./... -v

--- a/auth/azure-ad.go
+++ b/auth/azure-ad.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -110,7 +110,7 @@ func getAzureUserInfo(state string, code string) (*azureOauthUser, error) {
 		return nil, fmt.Errorf("failed getting user info: %s", err.Error())
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading response body: %s", err.Error())
 	}

--- a/auth/github.go
+++ b/auth/github.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gravitl/netmaker/logger"
@@ -113,7 +113,7 @@ func getGithubUserInfo(state string, code string) (*githubOauthUser, error) {
 		return nil, fmt.Errorf("failed getting user info: %s", err.Error())
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading response body: %s", err.Error())
 	}

--- a/auth/google.go
+++ b/auth/google.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gravitl/netmaker/logger"
@@ -104,7 +104,7 @@ func getGoogleUserInfo(state string, code string) (*googleOauthUser, error) {
 		return nil, fmt.Errorf("failed getting user info: %s", err.Error())
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading response body: %s", err.Error())
 	}

--- a/controllers/dns_test.go
+++ b/controllers/dns_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -200,7 +199,7 @@ func TestSetDNS(t *testing.T) {
 		info, err := os.Stat("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
 		assert.False(t, info.IsDir())
-		content, err := ioutil.ReadFile("./config/dnsconfig/netmaker.hosts")
+		content, err := os.ReadFile("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
 		assert.Contains(t, string(content), "testnode.skynet")
 	})
@@ -212,7 +211,7 @@ func TestSetDNS(t *testing.T) {
 		info, err := os.Stat("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
 		assert.False(t, info.IsDir())
-		content, err := ioutil.ReadFile("./config/dnsconfig/netmaker.hosts")
+		content, err := os.ReadFile("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
 		assert.Contains(t, string(content), "newhost.skynet")
 	})

--- a/controllers/response_test.go
+++ b/controllers/response_test.go
@@ -28,7 +28,7 @@ func TestReturnSuccessResponse(t *testing.T) {
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	//body, err := ioutil.ReadAll(resp.Body)
+	//body, err := io.ReadAll(resp.Body)
 	//assert.Nil(t, err)
 	//t.Log(body, string(body))
 	err := json.NewDecoder(resp.Body).Decode(&response)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 require (
 	cloud.google.com/go v0.34.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -90,7 +89,7 @@ func DumpFile(filePath string) {
 
 // Retrieve - retrieves logs from given file
 func Retrieve(filePath string) string {
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		panic(err)
 	}

--- a/logic/dns.go
+++ b/logic/dns.go
@@ -2,7 +2,6 @@ package logic
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-playground/validator/v10"
@@ -135,7 +134,7 @@ func SetCorefile(domains string) error {
 `
 	corebytes := []byte(corefile)
 
-	err = ioutil.WriteFile(dir+"/config/dnsconfig/Corefile", corebytes, 0644)
+	err = os.WriteFile(dir+"/config/dnsconfig/Corefile", corebytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/logic/wireguard.go
+++ b/logic/wireguard.go
@@ -3,7 +3,6 @@ package logic
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -89,7 +88,7 @@ func initWireguard(node *models.Node, privkey string, peers []wgtypes.PeerConfig
 		newConf, _ = ncutils.CreateUserSpaceConf(node.Address, key.String(), strconv.FormatInt(int64(node.ListenPort), 10), node.MTU, node.PersistentKeepalive, peers)
 		confPath := ncutils.GetNetclientPathSpecific() + ifacename + ".conf"
 		logger.Log(1, "writing wg conf file to:", confPath)
-		err = ioutil.WriteFile(confPath, []byte(newConf), 0644)
+		err = os.WriteFile(confPath, []byte(newConf), 0644)
 		if err != nil {
 			logger.Log(1, "error writing wg conf file to", confPath, ":", err.Error())
 			return err
@@ -97,7 +96,7 @@ func initWireguard(node *models.Node, privkey string, peers []wgtypes.PeerConfig
 		if ncutils.IsWindows() {
 			wgConfPath := ncutils.GetWGPathSpecific() + ifacename + ".conf"
 			logger.Log(1, "writing wg conf file to:", confPath)
-			err = ioutil.WriteFile(wgConfPath, []byte(newConf), 0644)
+			err = os.WriteFile(wgConfPath, []byte(newConf), 0644)
 			if err != nil {
 				logger.Log(1, "error writing wg conf file to", wgConfPath, ":", err.Error())
 				return err

--- a/netclient/auth/auth.go
+++ b/netclient/auth/auth.go
@@ -1,16 +1,14 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/config"
 	"github.com/gravitl/netmaker/netclient/ncutils"
-
-	//    "os"
-	"context"
-	"io/ioutil"
 
 	nodepb "github.com/gravitl/netmaker/grpc"
 	"google.golang.org/grpc/codes"
@@ -21,13 +19,13 @@ import (
 // SetJWT func will used to create the JWT while signing in and signing out
 func SetJWT(client nodepb.NodeServiceClient, network string) (context.Context, error) {
 	home := ncutils.GetNetclientPathSpecific()
-	tokentext, err := ioutil.ReadFile(home + "nettoken-" + network)
+	tokentext, err := os.ReadFile(home + "nettoken-" + network)
 	if err != nil {
 		err = AutoLogin(client, network)
 		if err != nil {
 			return nil, status.Errorf(codes.Unauthenticated, fmt.Sprintf("Something went wrong with Auto Login: %v", err))
 		}
-		tokentext, err = ioutil.ReadFile(home + "nettoken-" + network)
+		tokentext, err = os.ReadFile(home + "nettoken-" + network)
 		if err != nil {
 			return nil, status.Errorf(codes.Unauthenticated, fmt.Sprintf("Something went wrong: %v", err))
 		}
@@ -71,7 +69,7 @@ func AutoLogin(client nodepb.NodeServiceClient, network string) error {
 		return err
 	}
 	tokenstring := []byte(res.Data)
-	err = ioutil.WriteFile(home+"nettoken-"+network, tokenstring, 0644)
+	err = os.WriteFile(home+"nettoken-"+network, tokenstring, 0644)
 	if err != nil {
 		return err
 	}
@@ -81,13 +79,13 @@ func AutoLogin(client nodepb.NodeServiceClient, network string) error {
 // StoreSecret - stores auth secret locally
 func StoreSecret(key string, network string) error {
 	d1 := []byte(key)
-	err := ioutil.WriteFile(ncutils.GetNetclientPathSpecific()+"secret-"+network, d1, 0644)
+	err := os.WriteFile(ncutils.GetNetclientPathSpecific()+"secret-"+network, d1, 0644)
 	return err
 }
 
 // RetrieveSecret - fetches secret locally
 func RetrieveSecret(network string) (string, error) {
-	dat, err := ioutil.ReadFile(ncutils.GetNetclientPathSpecific() + "secret-" + network)
+	dat, err := os.ReadFile(ncutils.GetNetclientPathSpecific() + "secret-" + network)
 	return string(dat), err
 }
 

--- a/netclient/config/config.go
+++ b/netclient/config/config.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -133,12 +132,12 @@ func SaveBackup(network string) error {
 	var configPath = ncutils.GetNetclientPathSpecific() + "netconfig-" + network
 	var backupPath = ncutils.GetNetclientPathSpecific() + "backup.netconfig-" + network
 	if FileExists(configPath) {
-		input, err := ioutil.ReadFile(configPath)
+		input, err := os.ReadFile(configPath)
 		if err != nil {
 			ncutils.Log("failed to read " + configPath + " to make a backup")
 			return err
 		}
-		if err = ioutil.WriteFile(backupPath, input, 0644); err != nil {
+		if err = os.WriteFile(backupPath, input, 0644); err != nil {
 			ncutils.Log("failed to copy backup to " + backupPath)
 			return err
 		}
@@ -151,12 +150,12 @@ func ReplaceWithBackup(network string) error {
 	var backupPath = ncutils.GetNetclientPathSpecific() + "backup.netconfig-" + network
 	var configPath = ncutils.GetNetclientPathSpecific() + "netconfig-" + network
 	if FileExists(backupPath) {
-		input, err := ioutil.ReadFile(backupPath)
+		input, err := os.ReadFile(backupPath)
 		if err != nil {
 			ncutils.Log("failed to read file " + backupPath + " to backup network: " + network)
 			return err
 		}
-		if err = ioutil.WriteFile(configPath, input, 0644); err != nil {
+		if err = os.WriteFile(configPath, input, 0644); err != nil {
 			ncutils.Log("failed backup " + backupPath + " to " + configPath)
 			return err
 		}

--- a/netclient/daemon/macos.go
+++ b/netclient/daemon/macos.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func CreateMacService(servicename string, interval string) error {
 	daemonbytes := []byte(daemonstring)
 
 	if !ncutils.FileExists("/Library/LaunchDaemons/com.gravitl.netclient.plist") {
-		err = ioutil.WriteFile("/Library/LaunchDaemons/com.gravitl.netclient.plist", daemonbytes, 0644)
+		err = os.WriteFile("/Library/LaunchDaemons/com.gravitl.netclient.plist", daemonbytes, 0644)
 	}
 	return err
 }

--- a/netclient/daemon/systemd.go
+++ b/netclient/daemon/systemd.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	//"github.com/davecgh/go-spew/spew"
 
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -75,7 +74,7 @@ WantedBy=timers.target
 	timerbytes := []byte(systemtimer)
 
 	if !ncutils.FileExists("/etc/systemd/system/netclient.service") {
-		err = ioutil.WriteFile("/etc/systemd/system/netclient.service", servicebytes, 0644)
+		err = os.WriteFile("/etc/systemd/system/netclient.service", servicebytes, 0644)
 		if err != nil {
 			log.Println(err)
 			return err
@@ -83,7 +82,7 @@ WantedBy=timers.target
 	}
 
 	if !ncutils.FileExists("/etc/systemd/system/netclient.timer") {
-		err = ioutil.WriteFile("/etc/systemd/system/netclient.timer", timerbytes, 0644)
+		err = os.WriteFile("/etc/systemd/system/netclient.timer", timerbytes, 0644)
 		if err != nil {
 			log.Println(err)
 			return err

--- a/netclient/daemon/windows.go
+++ b/netclient/daemon/windows.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -57,7 +56,7 @@ func writeServiceConfig() error {
 </service>
 `, strings.Replace(ncutils.GetNetclientPathSpecific()+"netclient.exe", `\\`, `\`, -1))
 	if !ncutils.FileExists(serviceConfigPath) {
-		err := ioutil.WriteFile(serviceConfigPath, []byte(scriptString), 0644)
+		err := os.WriteFile(serviceConfigPath, []byte(scriptString), 0644)
 		if err != nil {
 			return err
 		}
@@ -84,12 +83,12 @@ func RemoveWindowsDaemon() {
 
 // func copyWinswOver() error {
 
-// 	input, err := ioutil.ReadFile(".\\winsw.exe")
+// 	input, err := os.ReadFile(".\\winsw.exe")
 // 	if err != nil {
 // 		ncutils.Log("failed to find winsw.exe")
 // 		return err
 // 	}
-// 	if err = ioutil.WriteFile(ncutils.GetNetclientPathSpecific()+"winsw.exe", input, 0644); err != nil {
+// 	if err = os.WriteFile(ncutils.GetNetclientPathSpecific()+"winsw.exe", input, 0644); err != nil {
 // 		ncutils.Log("failed to copy winsw.exe to " + ncutils.GetNetclientPath())
 // 		return err
 // 	}

--- a/netclient/local/dns.go
+++ b/netclient/local/dns.go
@@ -1,20 +1,17 @@
 package local
 
 import (
-	"io/ioutil"
-	"os"
-	"strings"
-
-	//"github.com/davecgh/go-spew/spew"
 	"log"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/gravitl/netmaker/netclient/ncutils"
 )
 
 // SetDNS - sets the DNS of a local machine
 func SetDNS(nameserver string) error {
-	bytes, err := ioutil.ReadFile("/etc/resolv.conf")
+	bytes, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
 		return err
 	}

--- a/netclient/ncutils/netclientutils.go
+++ b/netclient/ncutils/netclientutils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -132,7 +131,7 @@ func GetPublicIP() (string, error) {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				continue
 			}
@@ -409,7 +408,7 @@ func PrintLog(message string, loglevel int) {
 // GetSystemNetworks - get networks locally
 func GetSystemNetworks() ([]string, error) {
 	var networks []string
-	files, err := ioutil.ReadDir(GetNetclientPathSpecific())
+	files, err := os.ReadDir(GetNetclientPathSpecific())
 	if err != nil {
 		return networks, err
 	}

--- a/netclient/ncwindows/windows.go
+++ b/netclient/ncwindows/windows.go
@@ -1,7 +1,6 @@
 package ncwindows
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -24,12 +23,12 @@ func InitWindows() {
 
 	if os.IsNotExist(dataNetclientErr) { // check and see if netclient.exe is in appdata
 		if currentNetclientErr == nil { // copy it if it exists locally
-			input, err := ioutil.ReadFile(wdPath + "\\netclient.exe")
+			input, err := os.ReadFile(wdPath + "\\netclient.exe")
 			if err != nil {
 				log.Println("failed to find netclient.exe")
 				return
 			}
-			if err = ioutil.WriteFile(ncutils.GetNetclientPathSpecific()+"netclient.exe", input, 0644); err != nil {
+			if err = os.WriteFile(ncutils.GetNetclientPathSpecific()+"netclient.exe", input, 0644); err != nil {
 				log.Println("failed to copy netclient.exe to", ncutils.GetNetclientPath())
 				return
 			}

--- a/netclient/wireguard/common.go
+++ b/netclient/wireguard/common.go
@@ -3,7 +3,6 @@ package wireguard
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -179,14 +178,14 @@ func InitWireguard(node *models.Node, privkey string, peers []wgtypes.PeerConfig
 		}
 		confPath := ncutils.GetNetclientPathSpecific() + ifacename + ".conf"
 		ncutils.PrintLog("writing wg conf file to: "+confPath, 1)
-		err = ioutil.WriteFile(confPath, []byte(newConf), 0644)
+		err = os.WriteFile(confPath, []byte(newConf), 0644)
 		if err != nil {
 			ncutils.PrintLog("error writing wg conf file to "+confPath+": "+err.Error(), 1)
 			return err
 		}
 		if ncutils.IsWindows() {
 			wgConfPath := ncutils.GetWGPathSpecific() + ifacename + ".conf"
-			err = ioutil.WriteFile(wgConfPath, []byte(newConf), 0644)
+			err = os.WriteFile(wgConfPath, []byte(newConf), 0644)
 			if err != nil {
 				ncutils.PrintLog("error writing wg conf file to "+wgConfPath+": "+err.Error(), 1)
 				return err

--- a/netclient/wireguard/unix.go
+++ b/netclient/wireguard/unix.go
@@ -1,7 +1,6 @@
 package wireguard
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -67,7 +66,7 @@ func SyncWGQuickConf(iface string, confPath string) error {
 	}
 	regex := regexp.MustCompile(".*Warning.*\n")
 	conf := regex.ReplaceAllString(confRaw, "")
-	err = ioutil.WriteFile(tmpConf, []byte(conf), 0644)
+	err = os.WriteFile(tmpConf, []byte(conf), 0644)
 	if err != nil {
 		return err
 	}
@@ -94,12 +93,12 @@ func RemoveWGQuickConf(confPath string, printlog bool) error {
 func StorePrivKey(key string, network string) error {
 	var err error
 	d1 := []byte(key)
-	err = ioutil.WriteFile(ncutils.GetNetclientPathSpecific()+"wgkey-"+network, d1, 0644)
+	err = os.WriteFile(ncutils.GetNetclientPathSpecific()+"wgkey-"+network, d1, 0644)
 	return err
 }
 
 // RetrievePrivKey - reads wg priv key from local disk
 func RetrievePrivKey(network string) (string, error) {
-	dat, err := ioutil.ReadFile(ncutils.GetNetclientPathSpecific() + "wgkey-" + network)
+	dat, err := os.ReadFile(ncutils.GetNetclientPathSpecific() + "wgkey-" + network)
 	return string(dat), err
 }

--- a/servercfg/serverconf.go
+++ b/servercfg/serverconf.go
@@ -2,7 +2,7 @@ package servercfg
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -412,7 +412,7 @@ func GetPublicIP() (string, error) {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
This pull request introduces two small changes:

1. Upgrade to Go 1.17 to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading).

1. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.