### PR TITLE
Fix getting tag in Docker Publish workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -18,10 +18,10 @@ jobs:
         run: |
             if [[ -n "${{ github.event.inputs.tag }}" ]]; then
               TAG=${{ github.event.inputs.tag }}
-            elif [[ "${{ github.base_ref }}" == 'master' ]]; then
+            elif [[ "${{ github.ref_name }}" == 'master' ]]; then
               TAG="latest"
             else
-              TAG="${{ github.base_ref }}"
+              TAG="${{ github.ref_name }}"
             fi
             echo "TAG=${TAG}" >> $GITHUB_ENV
       - 


### PR DESCRIPTION
Get branch name/release tag from `github.ref_name` instead of `github.base_ref`. "base_ref property is only available when the event that triggers a workflow run is either pull_request or pull_request_target."

Source: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context