### PR TITLE
Fix default github url used when downloading latest netclient

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -188,7 +188,7 @@ if curl --output /dev/null --silent --head --fail "$url"; then
 	wget $curl_opts -O netclient $url
 else
 	echo "Downloading $dist latest"
-	wget $curl_opts -O netclient https://github.com/gravitl/netmaker/releases/download/latest/$dist
+	wget $curl_opts -O netclient https://github.com/gravitl/netmaker/releases/latest/download/$dist
 fi
 
 chmod +x netclient


### PR DESCRIPTION
Previous URL used when downloading `netclient` resulted in an HTTP 404 error resulting in `netclient-install.sh` failing.