### PR TITLE
Fix netclient install on ARMv6

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -127,6 +127,9 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
 			aarch64)
                                 dist=netclient-arm64
 			;;
+			armv6l)
+                                dist=netclient-arm6
+			;;
 			armv7l)
                                 dist=netclient-arm7
 			;;


### PR DESCRIPTION
`uname -m` gives `armv6l` on e.g. Raspberry Pi Zero. This was resulting in the script switch defaulting to
`https://github.com/gravitl/netmaker/releases/download/0.9.3/netclient-armv6l` instead of 
`https://github.com/gravitl/netmaker/releases/download/0.9.3/netclient-armv6`
and a 404.