### PR TITLE
Add basic security headers

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -5,6 +5,20 @@
 
 # Dashboard
 https://dashboard.NETMAKER_BASE_DOMAIN {
+    # Apply basic security headers
+    header {
+        # Enable HTTP Strict Transport Security (HSTS)
+        Strict-Transport-Security "max-age=31536000;"
+        # Enable cross-site filter (XSS) and tell browser to block detected attacks
+        X-XSS-Protection "1; mode=block"
+        # Disallow the site to be rendered within a frame on a foreign domain (clickjacking protection)
+        X-Frame-Options "SAMEORIGIN"
+        # Prevent search engines from indexing
+        X-Robots-Tag "none"
+        # Remove the server name
+        -Server
+    }
+
     reverse_proxy http://127.0.0.1:8082
 }
 

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,33 +1,33 @@
 {
-    # LetsEncrypt account
-    email YOUR_EMAIL
+        # LetsEncrypt account
+        email YOUR_EMAIL
 }
 
 # Dashboard
 https://dashboard.NETMAKER_BASE_DOMAIN {
-    # Apply basic security headers
-    header {
-        # Enable HTTP Strict Transport Security (HSTS)
-        Strict-Transport-Security "max-age=31536000;"
-        # Enable cross-site filter (XSS) and tell browser to block detected attacks
-        X-XSS-Protection "1; mode=block"
-        # Disallow the site to be rendered within a frame on a foreign domain (clickjacking protection)
-        X-Frame-Options "SAMEORIGIN"
-        # Prevent search engines from indexing
-        X-Robots-Tag "none"
-        # Remove the server name
-        -Server
-    }
+        # Apply basic security headers
+        header {
+                # Enable HTTP Strict Transport Security (HSTS)
+                Strict-Transport-Security "max-age=31536000;"
+                # Enable cross-site filter (XSS) and tell browser to block detected attacks
+                X-XSS-Protection "1; mode=block"
+                # Disallow the site to be rendered within a frame on a foreign domain (clickjacking protection)
+                X-Frame-Options "SAMEORIGIN"
+                # Prevent search engines from indexing
+                X-Robots-Tag "none"
+                # Remove the server name
+                -Server
+        }
 
-    reverse_proxy http://127.0.0.1:8082
+        reverse_proxy http://127.0.0.1:8082
 }
 
 # API
 https://api.NETMAKER_BASE_DOMAIN {
-    reverse_proxy http://127.0.0.1:8081
+        reverse_proxy http://127.0.0.1:8081
 }
 
 # gRPC
 https://grpc.NETMAKER_BASE_DOMAIN {
-    reverse_proxy h2c://127.0.0.1:50051
+        reverse_proxy h2c://127.0.0.1:50051
 }


### PR DESCRIPTION
Adds a few security related HTTP headers to the dashboard and formats the Caddyfile according to [caddy fmt](https://caddyserver.com/docs/command-line#caddy-fmt)

* enables [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
* enables[ X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
* restricts usage within iframes to prevent clickjacking via [X-Frame-Options](https://developer.mozilla.org/de/docs/Web/HTTP/Headers/X-Frame-Options)
* prevent the dashboard from being listed in search engines via [X-Robots-Tag](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag?hl=en#xrobotstag)
* removes the [Server](https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Server) header