### PR TITLE
Bugfix v0.10.0 node update delete

### DIFF
--- a/netclient/functions/common.go
+++ b/netclient/functions/common.go
@@ -303,8 +303,8 @@ func WipeLocal(network string) error {
 			log.Println(err.Error())
 		}
 	}
-	if ncutils.FileExists(home + "nm-" + network + ".conf") {
-		err = os.Remove(home + "nm-" + network + ".conf")
+	if ncutils.FileExists(home + ifacename + ".conf") {
+		err = os.Remove(home + ifacename + ".conf")
 		if err != nil {
 			log.Println("error removing .conf:")
 			log.Println(err.Error())

--- a/netclient/functions/common.go
+++ b/netclient/functions/common.go
@@ -262,25 +262,53 @@ func WipeLocal(network string) error {
 
 	home := ncutils.GetNetclientPathSpecific()
 	if ncutils.FileExists(home + "netconfig-" + network) {
-		_ = os.Remove(home + "netconfig-" + network)
+		err = os.Remove(home + "netconfig-" + network)
+		if err != nil {
+			log.Println("error removing netconfig:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "backup.netconfig-" + network) {
-		_ = os.Remove(home + "backup.netconfig-" + network)
+		err = os.Remove(home + "backup.netconfig-" + network)
+		if err != nil {
+			log.Println("error removing backup netconfig:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "nettoken-" + network) {
-		_ = os.Remove(home + "nettoken-" + network)
+		err = os.Remove(home + "nettoken-" + network)
+		if err != nil {
+			log.Println("error removing nettoken:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "secret-" + network) {
-		_ = os.Remove(home + "secret-" + network)
+		err = os.Remove(home + "secret-" + network)
+		if err != nil {
+			log.Println("error removing secret:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "traffic-" + network) {
-		_ = os.Remove(home + "traffic-" + network)
+		err = os.Remove(home + "traffic-" + network)
+		if err != nil {
+			log.Println("error removing traffic key:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "wgkey-" + network) {
-		_ = os.Remove(home + "wgkey-" + network)
+		err = os.Remove(home + "wgkey-" + network)
+		if err != nil {
+			log.Println("error removing wgkey:")
+			log.Println(err.Error())
+		}
 	}
 	if ncutils.FileExists(home + "nm-" + network + ".conf") {
-		_ = os.Remove(home + "nm-" + network + ".conf")
+		err = os.Remove(home + "nm-" + network + ".conf")
+		if err != nil {
+			log.Println("error removing .conf:")
+			log.Println(err.Error())
+		}
 	}
 	return err
 }

--- a/netclient/functions/daemon.go
+++ b/netclient/functions/daemon.go
@@ -254,6 +254,7 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 		cfg.Node = newNode
 		switch newNode.Action {
 		case models.NODE_DELETE:
+			ncutils.Log("delete recieved")
 			if token := client.Unsubscribe(fmt.Sprintf("update/%s/%s", newNode.Network, newNode.ID), fmt.Sprintf("peers/%s/%s", newNode.Network, newNode.ID)); token.Wait() && token.Error() != nil {
 				ncutils.PrintLog("error unsubscribing during node deletion", 1)
 			}
@@ -270,11 +271,13 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 			}
 			return
 		case models.NODE_UPDATE_KEY:
+			ncutils.Log("delete recieved")
 			if err := UpdateKeys(&cfg, client); err != nil {
 				ncutils.PrintLog("err updating wireguard keys: "+err.Error(), 1)
 			}
 			ifaceDelta = true
 		case models.NODE_NOOP:
+			ncutils.Log("noop recieved")
 		default:
 		}
 		//Save new config


### PR DESCRIPTION
All go routines associated with a deleted network are stopped and network config files are deleted.
added context and waitgroups to all child go routines.