### PR TITLE
Set ext_client mtu to match ingress gw

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -154,6 +154,7 @@ func getExtClientConf(w http.ResponseWriter, r *http.Request) {
 	config := fmt.Sprintf(`[Interface]
 Address = %s
 PrivateKey = %s
+MTU = %d
 %s
 
 [Peer]
@@ -164,6 +165,7 @@ Endpoint = %s
 
 `, client.Address+"/32",
 		client.PrivateKey,
+		gwnode.MTU,
 		defaultDNS,
 		gwnode.PublicKey,
 		newAllowedIPs,


### PR DESCRIPTION
Currently the external client configuration does not specify a MTU,
which causes WireGuard to use the default of 1420. The default of the
ingress gateway will be 1280. This mismatch can cause network issues.

This patch ensures that the generated external client configuration is
specified to use a MTU that matches that one the ingress gateway.

I have to admit that I have not been able to test this, since I don't really
have a testing setup in the first place. Although it seems like this should
do the trick.

Fix #857 