### PR TITLE
config/config_test: add tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ func getEnv() string {
 
 // Config : application config stored as global variable
 var Config *EnvironmentConfig
+var SetupErr error
 
 // EnvironmentConfig - environment conf struct
 type EnvironmentConfig struct {
@@ -90,25 +91,26 @@ type SQLConfig struct {
 }
 
 // reading in the env file
-func readConfig() *EnvironmentConfig {
-	file := fmt.Sprintf("config/environments/%s.yaml", getEnv())
+func readConfig() (*EnvironmentConfig, error) {
+	file := fmt.Sprintf("environments/%s.yaml", getEnv())
 	f, err := os.Open(file)
 	var cfg EnvironmentConfig
 	if err != nil {
-		return &cfg
+		return &cfg, err
 	}
 	defer f.Close()
 
 	decoder := yaml.NewDecoder(f)
-	err = decoder.Decode(&cfg)
-	if err != nil {
-		log.Fatal(err)
-		os.Exit(2)
+	if decoder.Decode(&cfg) != nil {
+		return &cfg, err
 	}
-	return &cfg
+	return &cfg, err
 
 }
 
 func init() {
-	Config = readConfig()
+	if Config, SetupErr = readConfig(); SetupErr != nil {
+		log.Fatal(SetupErr)
+		os.Exit(2)
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,36 @@
+//Environment file for getting variables
+//Currently the only thing it does is set the master password
+//Should probably have it take over functions from OS such as port and mongodb connection details
+//Reads from the config/environments/dev.yaml file by default
 package config
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-func TestReadConfig(t *testing.T) {
-	config := readConfig()
-	t.Log(config)
+func Test_readConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    *EnvironmentConfig
+		wantErr bool
+	}{
+		{
+			"ensure development config parses",
+			&EnvironmentConfig{},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readConfig()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("readConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
* Adds a test for parsing the dev.yaml config included in the repository
* Changes readConfig() to return an error in addition to the envrionment
  config

Signed-off-by: John Sahhar <john@gravitl.com>