### PR TITLE
netclient: pass by value -> reference

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -110,7 +109,6 @@ func readConfig() (*EnvironmentConfig, error) {
 
 func init() {
 	if Config, SetupErr = readConfig(); SetupErr != nil {
-		log.Fatal(SetupErr)
-		os.Exit(2)
+		Config = &EnvironmentConfig{}
 	}
 }

--- a/netclient/cli_options/cmds.go
+++ b/netclient/cli_options/cmds.go
@@ -28,7 +28,7 @@ func GetCommands(cliFlags []cli.Flag) []*cli.Command {
 					err = errors.New("no server address provided")
 					return err
 				}
-				err = command.Join(cfg, pvtKey)
+				err = command.Join(&cfg, pvtKey)
 				return err
 			},
 		},
@@ -43,7 +43,7 @@ func GetCommands(cliFlags []cli.Flag) []*cli.Command {
 				if err != nil {
 					return err
 				}
-				err = command.Leave(cfg, c.String("force") == "yes")
+				err = command.Leave(&cfg, c.String("force") == "yes")
 				return err
 			},
 		},
@@ -58,7 +58,7 @@ func GetCommands(cliFlags []cli.Flag) []*cli.Command {
 				if err != nil {
 					return err
 				}
-				err = command.Pull(cfg)
+				err = command.Pull(&cfg)
 				return err
 			},
 		},

--- a/netclient/command/commands.go
+++ b/netclient/command/commands.go
@@ -10,11 +10,6 @@ import (
 	"github.com/gravitl/netmaker/netclient/ncutils"
 )
 
-type (
-	AuthenticationKey struct {
-	}
-)
-
 // JoinComms -- Join the message queue comms network if it doesn't have it
 // tries to ping if already found locally, if fail ping pull for best effort for communication
 func JoinComms(cfg *config.ClientConfig) error {

--- a/netclient/config/config.go
+++ b/netclient/config/config.go
@@ -24,6 +24,7 @@ type ClientConfig struct {
 	Daemon          string         `yaml:"daemon"`
 	OperatingSystem string         `yaml:"operatingsystem"`
 	DebugOn         bool           `yaml:"debugon"`
+	
 }
 
 // ServerConfig - struct for dealing with the server information for a netclient

--- a/netclient/daemon/common.go
+++ b/netclient/daemon/common.go
@@ -9,7 +9,7 @@ import (
 )
 
 // InstallDaemon - Calls the correct function to install the netclient as a daemon service on the given operating system.
-func InstallDaemon(cfg config.ClientConfig) error {
+func InstallDaemon(cfg *config.ClientConfig) error {
 	os := runtime.GOOS
 	var err error
 

--- a/netclient/functions/join.go
+++ b/netclient/functions/join.go
@@ -24,7 +24,7 @@ import (
 )
 
 // JoinNetwork - helps a client join a network
-func JoinNetwork(cfg config.ClientConfig, privateKey string, iscomms bool) error {
+func JoinNetwork(cfg *config.ClientConfig, privateKey string, iscomms bool) error {
 	if cfg.Node.Network == "" {
 		return errors.New("no network provided")
 	}
@@ -35,7 +35,7 @@ func JoinNetwork(cfg config.ClientConfig, privateKey string, iscomms bool) error
 		return err
 	}
 
-	err = config.Write(&cfg, cfg.Network)
+	err = config.Write(cfg, cfg.Network)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func JoinNetwork(cfg config.ClientConfig, privateKey string, iscomms bool) error
 
 	cfg.Node = node
 
-	setListenPort(oldListenPort, &cfg)
+	setListenPort(oldListenPort, cfg)
 
 	err = config.ModConfig(&cfg.Node)
 	if err != nil {


### PR DESCRIPTION
Updates various function arguments to accept `config.ClientConfig`
by reference instead of by value.

Signed-off-by: John Sahhar <john@gravitl.com>