### PR TITLE
scripts/build-binaries.sh: support for all OS/ARCH

### DIFF
--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ ${#VERSION} -lt 1 ]]; then VERSION="develop"; fi 
+VERSION=${VERSION:-"develop"}
 echo "build with version tag: $VERSION"
 readonly __HOST_ARCH=${1:-"amd64"}  # change this for your machine.
 readonly __HOST_GOOSE=${2:-"linux"} # change this for your machine.

--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [[ ${#VERSION} -lt 1 ]]; then VERSION="develop"; fi 
+echo "build with version tag: $VERSION"
+readonly __HOST_ARCH=${1:-"amd64"}  # change this for your machine.
+readonly __HOST_GOOSE=${2:-"linux"} # change this for your machine.
+readonly __EXEC_DIR=$(dirname "$(realpath $0)") && cd $__EXEC_DIR   
+
+__darwin=( arm64 amd64 )
+__linux=( amd64 arm arm64 mips mips64 mips64le mipsle ppc64 ppc64le riscv64 s390x 386 )
+__freebsd=( amd64 arm arm64 386 )
+__windows=( amd64 arm arm64 386 ) 
+
+function build
+{   
+    local _goarch=${1:-"None"} && if [[ $_goarch == "None" ]]; then exit 1; fi
+    local _goose="${2:-"None"}" && if [[ $_goose == "None" ]]; then exit 1; fi
+    local _goarm=${3:-""}
+    local _out=build/netclient-$_goose-$_goarch$_goarm && mkdir -p build
+    if [ "$_goarch" == "arm" ] && [ "$_goarm" == "" ]; then
+	    build $_goarch $_goose 5 && build $_goarch $_goose 6 && build $_goarch $_goose 7
+    else
+        echo $_out
+        GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+    fi
+}
+
+for arch in ${__linux[*]}; do build "$arch" "linux"; done
+
+for arch in ${__freebsd[*]}; do build "$arch" "freebsd"; done
+
+for arch in ${__darwin[*]}; do build "$arch" "darwin"; done
+
+for arch in ${__windows[*]}; do build "$arch" "windows"; done
+

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -4,18 +4,5 @@
 env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.version=$VERSION'" -o netclient/build/netmaker main.go
 
 cd netclient
+./bin-maker.sh
 
-#client build
-env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient main.go
-env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-arm5 main.go
-env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-arm6 main.go
-env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-arm7 main.go
-env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-arm64 main.go
-env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -ldflags "-s -w -X 'main.version=$VERSION'" -o build/netclient-mipsle main.go && upx build/netclient-mipsle
-env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build  -ldflags="-X 'main.version=$VERSION'" -o build/netclient-freebsd main.go
-env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm GOARM=5 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-freebsd-arm5 main.go
-env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm GOARM=6 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-freebsd-arm6 main.go
-env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm GOARM=7 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-freebsd-arm7 main.go
-env CGO_ENABLED=0 GOOS=freebsd GOARCH=arm64 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-freebsd-arm64 main.go
-env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-X 'main.version=$VERSION'" -o build/netclient-darwin main.go
-env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-X 'main.version=${VERSION}'" -o build/netclient-darwin-arm64 main.go


### PR DESCRIPTION
Expands our build scripts to support the following OS/ARCHS:
```
netclient-linux-amd64
netclient-linux-arm5
netclient-linux-arm6
netclient-linux-arm7
netclient-linux-arm64
netclient-linux-mips
netclient-linux-mips64
netclient-linux-mips64le
netclient-linux-mipsle
netclient-linux-ppc64
netclient-linux-ppc64le
netclient-linux-riscv64
netclient-linux-s390x
netclient-linux-386
netclient-freebsd-amd64
netclient-freebsd-arm5
netclient-freebsd-arm6
netclient-freebsd-arm7
netclient-freebsd-arm64
netclient-freebsd-386
netclient-darwin-arm64
netclient-darwin-amd64
netclient-windows-amd64
netclient-windows-arm5
netclient-windows-arm6
netclient-windows-arm7
netclient-windows-arm64
netclient-windows-386
```
Signed-off-by: John Sahhar <john@gravitl.com>