### PR TITLE
config/version: switch VERSION to constant

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -18,11 +18,7 @@ jobs:
     steps:
       - name: Get Version Number
         run: |
-          if [[ -n "${{ github.event.inputs.version }}" ]]; then
-            NETMAKER_VERSION=${{ github.event.inputs.version }}
-          else
-            NETMAKER_VERSION=$(curl -fsSL https://api.github.com/repos/gravitl/netmaker/tags | grep 'name' | head -1 | cut -d'"' -f4)
-          fi
+          NETMAKER_VERSION=$(cat config/version.go | grep VERSION | cut -c 12- | tr -d "\"")
           echo "NETMAKER_VERSION=${NETMAKER_VERSION}" >> $GITHUB_ENV
           # remove everything but digits and . for package (deb, rpm, etc) versions
           PACKAGE_VERSION=$(echo ${NETMAKER_VERSION} | tr -cd '[:digit:].')

--- a/config/version.go
+++ b/config/version.go
@@ -1,0 +1,5 @@
+package config
+
+const (
+	VERSION = "v0.12.1-c784f99"
+)

--- a/logic/server.go
+++ b/logic/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitl/netmaker/config"
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/logic/acls"
 	"github.com/gravitl/netmaker/logic/acls/nodeacls"
@@ -70,7 +71,7 @@ func ServerJoin(networkSettings *models.Network) (models.Node, error) {
 		IsLocal:      networkSettings.IsLocal,
 		LocalRange:   networkSettings.LocalRange,
 		OS:           runtime.GOOS,
-		Version:      servercfg.Version,
+		Version:      config.VERSION,
 		IsHub:        ishub,
 	}
 

--- a/logic/telemetry.go
+++ b/logic/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gravitl/netmaker/config"
 	"github.com/gravitl/netmaker/database"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/servercfg"
@@ -64,7 +65,7 @@ func fetchTelemetryData() (telemetryData, error) {
 	data.ExtClients = getDBLength(database.EXT_CLIENT_TABLE_NAME)
 	data.Users = getDBLength(database.USERS_TABLE_NAME)
 	data.Networks = getDBLength(database.NETWORKS_TABLE_NAME)
-	data.Version = servercfg.GetVersion()
+	data.Version = config.VERSION
 	nodes, err := GetAllNodes()
 	if err == nil {
 		data.Nodes = len(nodes)

--- a/main.go
+++ b/main.go
@@ -26,11 +26,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-var version = "dev"
-
 // Start DB Connection and start API Request Handler
 func main() {
-	servercfg.SetVersion(version)
 	fmt.Println(models.RetrieveLogo()) // print the logo
 	initialize()                       // initial db and grpc server
 	setGarbageCollection()

--- a/netclient/functions/join.go
+++ b/netclient/functions/join.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 
 	nodepb "github.com/gravitl/netmaker/grpc"
+
+	_cfg "github.com/gravitl/netmaker/config"
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/auth"
@@ -146,7 +148,7 @@ func JoinNetwork(cfg *config.ClientConfig, privateKey string, iscomms bool) erro
 		UDPHolePunch:        cfg.Node.UDPHolePunch,
 		TrafficKeys:         cfg.Node.TrafficKeys,
 		OS:                  runtime.GOOS,
-		Version:             ncutils.Version,
+		Version:             _cfg.VERSION,
 	}
 
 	logger.Log(0, "joining "+cfg.Network+" at "+cfg.Server.GRPCAddress)

--- a/netclient/functions/mqpublish.go
+++ b/netclient/functions/mqpublish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/netclient/auth"
 	"github.com/gravitl/netmaker/netclient/config"
+	cfg "github.com/gravitl/netmaker/config"
 	"github.com/gravitl/netmaker/netclient/ncutils"
 )
 
@@ -106,7 +107,7 @@ func PublishNodeUpdate(commsCfg, nodeCfg *config.ClientConfig) error {
 
 // Hello -- ping the broker to let server know node it's alive and well
 func Hello(commsCfg, nodeCfg *config.ClientConfig) {
-	if err := publish(commsCfg, nodeCfg, fmt.Sprintf("ping/%s", nodeCfg.Node.ID), []byte(ncutils.Version), 0); err != nil {
+	if err := publish(commsCfg, nodeCfg, fmt.Sprintf("ping/%s", nodeCfg.Node.ID), []byte(cfg.VERSION), 0); err != nil {
 		logger.Log(0, fmt.Sprintf("error publishing ping, %v", err))
 		logger.Log(0, "running pull on "+commsCfg.Node.Network+" to reconnect")
 		_, err := Pull(commsCfg.Node.Network, true)

--- a/netclient/main.go
+++ b/netclient/main.go
@@ -7,20 +7,18 @@ import (
 	"os"
 	"runtime/debug"
 
+	cfg "github.com/gravitl/netmaker/config"
 	"github.com/gravitl/netmaker/netclient/cli_options"
 	"github.com/gravitl/netmaker/netclient/ncutils"
 	"github.com/gravitl/netmaker/netclient/ncwindows"
 	"github.com/urfave/cli/v2"
 )
 
-var version = "dev"
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "Netclient CLI"
 	app.Usage = "Netmaker's netclient agent and CLI. Used to perform interactions with Netmaker server and set local WireGuard config."
-	app.Version = version
-	ncutils.SetVersion(version)
+	app.Version = cfg.VERSION
 
 	cliFlags := cli_options.GetFlags(ncutils.GetHostname())
 	app.Commands = cli_options.GetCommands(cliFlags[:])

--- a/netclient/ncutils/netclientutils.go
+++ b/netclient/ncutils/netclientutils.go
@@ -27,9 +27,6 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// Version - version of the netclient
-var Version = "dev"
-
 // src - for random strings
 var src = rand.NewSource(time.Now().UnixNano())
 
@@ -70,11 +67,6 @@ const (
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
-
-// SetVersion -- set netclient version for use by other packages
-func SetVersion(ver string) {
-	Version = ver
-}
 
 // IsWindows - checks if is windows
 func IsWindows() bool {

--- a/servercfg/serverconf.go
+++ b/servercfg/serverconf.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	Version = "dev"
 	commsID = ""
 )
 
@@ -78,7 +77,7 @@ func GetServerConfig() config.ServerConfig {
 	}
 	cfg.Database = GetDB()
 	cfg.Platform = GetPlatform()
-	cfg.Version = GetVersion()
+	cfg.Version = config.VERSION
 
 	// == auth config ==
 	var authInfo = GetAuthProviderInfo()
@@ -121,16 +120,6 @@ func GetAPIConnString() string {
 		conn = config.Config.Server.APIConnString
 	}
 	return conn
-}
-
-// SetVersion - set version of netmaker
-func SetVersion(v string) {
-	Version = v
-}
-
-// GetVersion - version of netmaker
-func GetVersion() string {
-	return Version
 }
 
 // GetDB - gets the database type


### PR DESCRIPTION
Switches Version from a runtime var to a constant.
This constant, VERSION, should be updated manually
with each semantic version change & commit to master.

The format is:

	semvar-commithash[:7]

For example:

	v0.12.1-c784f99

Hardcoding the semantic version as a constant allows us to implement
controls for preventing mismatched net{client,maker}
binaries from interacting.

These controls become critical to the security of netmaker networks
in the event of a vulnerability wherein the resolving patch increments
the semnatic version. In this scenario, controls to automatically
prevent vulernable (read: out-of-date) binaries from interacting
with the latest, patched binaries are crucial.

Signed-off-by: John Sahhar <john@gravitl.com>