### PR TITLE
main: Add flag (-c) for configuration path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,18 +13,15 @@ import (
 
 // setting dev by default
 func getEnv() string {
-
 	env := os.Getenv("NETMAKER_ENV")
-
 	if len(env) == 0 {
 		return "dev"
 	}
-
 	return env
 }
 
 // Config : application config stored as global variable
-var Config *EnvironmentConfig
+var Config *EnvironmentConfig = &EnvironmentConfig{}
 var SetupErr error
 
 // EnvironmentConfig - environment conf struct
@@ -90,9 +87,11 @@ type SQLConfig struct {
 }
 
 // reading in the env file
-func readConfig() (*EnvironmentConfig, error) {
-	file := fmt.Sprintf("environments/%s.yaml", getEnv())
-	f, err := os.Open(file)
+func ReadConfig(absolutePath string) (*EnvironmentConfig, error) {
+	if len(absolutePath) == 0 {
+		absolutePath = fmt.Sprintf("environments/%s.yaml", getEnv())
+	}
+	f, err := os.Open(absolutePath)
 	var cfg EnvironmentConfig
 	if err != nil {
 		return &cfg, err
@@ -104,11 +103,4 @@ func readConfig() (*EnvironmentConfig, error) {
 		return &cfg, err
 	}
 	return &cfg, err
-
-}
-
-func init() {
-	if Config, SetupErr = readConfig(); SetupErr != nil {
-		Config = &EnvironmentConfig{}
-	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func Test_readConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readConfig()
+			got, err := ReadConfig("")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/gravitl/netmaker/auth"
+	"github.com/gravitl/netmaker/config"
 	controller "github.com/gravitl/netmaker/controllers"
 	"github.com/gravitl/netmaker/database"
 	"github.com/gravitl/netmaker/functions"
@@ -30,12 +32,27 @@ var version = "dev"
 
 // Start DB Connection and start API Request Handler
 func main() {
+	absoluteConfigPath := flag.String("c", "", "absolute path to configuration file")
+	flag.Parse()
+
+	setupConfig(*absoluteConfigPath)
 	servercfg.SetVersion(version)
 	fmt.Println(models.RetrieveLogo()) // print the logo
 	initialize()                       // initial db and grpc server
 	setGarbageCollection()
 	defer database.CloseDB()
 	startControllers() // start the grpc or rest endpoints
+}
+
+func setupConfig(absoluteConfigPath string) {
+	if len(absoluteConfigPath) > 0 {
+		cfg, err := config.ReadConfig(absoluteConfigPath)
+		if err != nil {
+			logger.Log(0, fmt.Sprintf("failed parsing config at: %s", absoluteConfigPath))
+			return
+		}
+		config.Config = cfg
+	}
 }
 
 func initialize() { // Client Mode Prereq Check


### PR DESCRIPTION
Adds an optional flag (-c) to the netmaker binary
for passing in an absolute path to a netmaker config
file.

Example:

	netmaker -c /etc/default/netmaker-server.yaml

Signed-off-by: John Sahhar <john@gravitl.com>