### PR TITLE
fix: Fixed wrong Image Tag

### DIFF
--- a/compose/docker-compose.hostnetwork.yml
+++ b/compose/docker-compose.hostnetwork.yml
@@ -41,7 +41,7 @@ services:
     container_name: netmaker-ui
     depends_on:
       - netmaker
-    image: gravitl/netmaker-ui:0.12.1
+    image: gravitl/netmaker-ui:v0.12.1
     links:
       - "netmaker:api"
     ports:


### PR DESCRIPTION
Updated image tag to `gravitl/netmaker-ui:v0.12.1`