### PR TITLE
Fix docker config to avoid exposing ports unnecessarily

### DIFF
--- a/compose/docker-compose.contained.yml
+++ b/compose/docker-compose.contained.yml
@@ -39,8 +39,6 @@ services:
       VERBOSITY: "1"
     ports:
       - "51821-51830:51821-51830/udp"
-      - "8081:8081"
-      - "50051:50051"
   netmaker-ui:
     container_name: netmaker-ui
     depends_on:
@@ -48,8 +46,6 @@ services:
     image: gravitl/netmaker-ui:v0.12.1
     links:
       - "netmaker:api"
-    ports:
-      - "8082:80"
     environment:
       BACKEND_URL: "https://api.NETMAKER_BASE_DOMAIN"
     restart: always
@@ -66,7 +62,9 @@ services:
     image: caddy:latest
     container_name: caddy
     restart: unless-stopped
-    network_mode: host # Wants ports 80 and 443!
+    ports:
+      - "80:80"
+      - "443:443"
     volumes:
       - /root/Caddyfile:/etc/caddy/Caddyfile
       # - $PWD/site:/srv # you could also serve a static site in site folder
@@ -76,8 +74,6 @@ services:
     image: eclipse-mosquitto:2.0.14
     container_name: mq
     restart: unless-stopped
-    ports:
-      - "1883:1883"
     volumes:
       - /root/mosquitto.conf:/mosquitto/config/mosquitto.conf
       - mosquitto_data:/mosquitto/data

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -21,15 +21,15 @@ https://dashboard.NETMAKER_BASE_DOMAIN {
                 -Server
         }
 
-        reverse_proxy http://127.0.0.1:8082
+        reverse_proxy http://netmaker-ui
 }
 
 # API
 https://api.NETMAKER_BASE_DOMAIN {
-        reverse_proxy http://127.0.0.1:8081
+        reverse_proxy http://netmaker:8081
 }
 
 # gRPC
 https://grpc.NETMAKER_BASE_DOMAIN {
-        reverse_proxy h2c://127.0.0.1:50051
+        reverse_proxy h2c://netmaker:50051
 }

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -174,23 +174,23 @@ sleep 2
 setup_mesh() {
 echo "creating default network (10.101.0.0/16)"
 
-curl -s -o /dev/null -d '{"addressrange":"10.101.0.0/16","netid":"default"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/networks
+curl -s -o /dev/null -d '{"addressrange":"10.101.0.0/16","netid":"default"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/networks
 
 sleep 2
 
 echo "creating default key"
 
-curlresponse=$(curl -s -d '{"uses":99999,"name":"defaultkey"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/networks/default/keys)
+curlresponse=$(curl -s -d '{"uses":99999,"name":"defaultkey"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/networks/default/keys)
 ACCESS_TOKEN=$(jq -r '.accessstring' <<< ${curlresponse})
 
 sleep 2
 
 echo "configuring netmaker server as ingress gateway"
 
-curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/default)
+curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/default)
 SERVER_ID=$(jq -r '.[0].id' <<< ${curlresponse})
 
-curl -o /dev/null -s -X POST -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/default/$SERVER_ID/createingress
+curl -o /dev/null -s -X POST -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/default/$SERVER_ID/createingress
 
 echo "finished configuring server and network. You can now add clients."
 echo ""
@@ -215,16 +215,16 @@ echo "Netmaker setup is now complete. You are ready to begin using Netmaker."
 setup_vpn() {
 echo "creating vpn network (10.201.0.0/16)"
 
-curl -s -o /dev/null -d '{"addressrange":"10.201.0.0/16","netid":"vpn","defaultextclientdns":"8.8.8.8"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/networks
+curl -s -o /dev/null -d '{"addressrange":"10.201.0.0/16","netid":"vpn","defaultextclientdns":"8.8.8.8"}' -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/networks
 
 sleep 2
 
 echo "configuring netmaker server as vpn inlet..."
 
-curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/vpn)
+curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/vpn)
 SERVER_ID=$(jq -r '.[0].id' <<< ${curlresponse})
 
-curl -s -o /dev/null -X POST -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/vpn/$SERVER_ID/createingress
+curl -s -o /dev/null -X POST -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/vpn/$SERVER_ID/createingress
 
 echo "waiting 10 seconds for server to apply configuration..."
 
@@ -237,7 +237,7 @@ echo "configuring netmaker server vpn gateway..."
 
 echo "gateway iface: $GATEWAY_IFACE"
 
-curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/vpn)
+curlresponse=$(curl -s -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/vpn)
 SERVER_ID=$(jq -r '.[0].id' <<< ${curlresponse})
 
 EGRESS_JSON=$( jq -n \
@@ -246,7 +246,7 @@ EGRESS_JSON=$( jq -n \
 
 
 echo "egress json: $EGRESS_JSON"
-curl -s -o /dev/null -X POST -d "$EGRESS_JSON" -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/nodes/vpn/$SERVER_ID/creategateway
+curl -s -o /dev/null -X POST -d "$EGRESS_JSON" -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/nodes/vpn/$SERVER_ID/creategateway
 
 echo "creating client configs..."
 
@@ -256,7 +256,7 @@ do
                   --arg clientid "vpnclient-$a" \
                   '{clientid: $clientid}' )
 
-        curl -s -o /dev/null -d "$CLIENT_JSON" -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' localhost:8081/api/extclients/vpn/$SERVER_ID
+        curl -s -o /dev/null -d "$CLIENT_JSON" -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' https://api.${NETMAKER_BASE_DOMAIN}/api/extclients/vpn/$SERVER_ID
 done
 
 echo "finished configuring vpn server."


### PR DESCRIPTION
Hello,

I gave netmaker a try today and it looks great. However the "quick install" method using docker-compose seems to expose ports to the outside world unnecessarily. Even though this could be "fixed" by setting firewall rules I think it's better to not expose those ports in a first place since it makes the "quick install" more secure by default.

This PR is an attempt to fix this issue by using the network created by docker-compose to communicate between the containers instead of exposing all the services to 0.0.0.0 on the host.

I tested the fix with the nm-quick.sh script and everything looks good, however I'm not 100% sure my changes don't have an impact on other deployment methods (especially the Caddyfile changes). Let me know what you think about it.

Cheers,
Boris