### PR TITLE
Fix docker-compose.hostnetwork.yml netmaker-ui

### DIFF
--- a/compose/docker-compose.hostnetwork.yml
+++ b/compose/docker-compose.hostnetwork.yml
@@ -41,7 +41,7 @@ services:
     container_name: netmaker-ui
     depends_on:
       - netmaker
-    image: gravitl/netmaker-ui:0.12.2
+    image: gravitl/netmaker-ui:v0.12.2
     links:
       - "netmaker:api"
     ports:


### PR DESCRIPTION
Hi,
while doing the setup I found that ```netmaker-ui``` was set to ```0.12.2``` instead of ```v0.12.2```