### PR TITLE
adding DNS to docker-compose

### DIFF
--- a/compose/docker-compose.contained.yml
+++ b/compose/docker-compose.contained.yml
@@ -35,7 +35,8 @@ services:
       MQ_HOST: "mq"
       HOST_NETWORK: "off"
       VERBOSITY: "1"
-      MANAGE_IPTABLES: "off"
+      MANAGE_IPTABLES: "on"
+      PORT_FORWARD_SERVICES: "dns"
     ports:
       - "51821-51830:51821-51830/udp"
       - "8081:8081"

--- a/compose/docker-compose.hostnetwork.yml
+++ b/compose/docker-compose.hostnetwork.yml
@@ -32,7 +32,8 @@ services:
       HOST_NETWORK: "on"
       NODE_ID: "netmaker-server-1"
       VERBOSITY: "1"
-      MANAGE_IPTABLES: "off"
+      MANAGE_IPTABLES: "on"
+      PORT_FORWARD_SERVICES: "dns"
   netmaker-ui:
     container_name: netmaker-ui
     depends_on:

--- a/compose/docker-compose.nocaddy.yml
+++ b/compose/docker-compose.nocaddy.yml
@@ -35,7 +35,8 @@ services:
       MQ_HOST: "mq"
       HOST_NETWORK: "off"
       VERBOSITY: "1"
-      MANAGE_IPTABLES: "off"
+      MANAGE_IPTABLES: "on"
+      PORT_FORWARD_SERVICES: "dns"
     ports:
       - "51821-51830:51821-51830/udp"
       - "8081:8081"

--- a/compose/docker-compose.nodns.yml
+++ b/compose/docker-compose.nodns.yml
@@ -35,7 +35,8 @@ services:
       MQ_HOST: "mq"
       HOST_NETWORK: "off"
       VERBOSITY: "1"
-      MANAGE_IPTABLES: "off"
+      MANAGE_IPTABLES: "on"
+      PORT_FORWARD_SERVICES: "dns"
     ports:
       - "51821-51830:51821-51830/udp"
       - "8081:8081"

--- a/compose/docker-compose.reference.yml
+++ b/compose/docker-compose.reference.yml
@@ -37,7 +37,8 @@ services:
       TELEMETRY: "on" # Whether or not to send telemetry data to help improve Netmaker. Switch to "off" to opt out of sending telemetry.
       MQ_HOST: "mq" # the address of the mq server. If running from docker compose it will be "mq". Otherwise, need to input address. If using "host networking", it will find and detect the IP of the mq container.
       HOST_NETWORK: "off" # whether or not host networking is turned on. Only turn on if configured for host networking (see docker-compose.hostnetwork.yml). Will set host-level settings like iptables.
-      MANAGE_IPTABLES: "off" # deprecated
+      MANAGE_IPTABLES: "on" # deprecated
+      PORT_FORWARD_SERVICES: "dns" # decide which services to port forward ("dns","ssh", or "mq")
     ports:
       - "51821-51830:51821-51830/udp"
       - "8081:8081"

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -35,7 +35,8 @@ services:
       MQ_HOST: "mq"
       HOST_NETWORK: "off"
       VERBOSITY: "1"
-      MANAGE_IPTABLES: "off"
+      PORT_FORWARD_SERVICES: "dns"
+      MANAGE_IPTABLES: "on"
     ports:
       - "51821-51830:51821-51830/udp"
       - "8081:8081"


### PR DESCRIPTION
This allows DNS to be reachable from clients. Port forwarding is necessary for this to work. Can be added to "default ext client dns" successfully.