### PR TITLE
Add missing mosquitto certs path mapping

### DIFF
--- a/compose/docker-compose.nocaddy.yml
+++ b/compose/docker-compose.nocaddy.yml
@@ -73,6 +73,7 @@ services:
       - "8883:8883"
     volumes:
       - /root/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - /root/certs/:/mosquitto/certs/
       - mosquitto_data:/mosquitto/data
       - mosquitto_logs:/mosquitto/log
 volumes:


### PR DESCRIPTION
This PR adds missing mosquitto certs path mapping to compose/docker-compose.nocaddy.yml

While installing the netmaker server, it took me a while to find out what's missing.