### PR TITLE
force lowercase for /etc/hosts profile names

### DIFF
--- a/logic/networks.go
+++ b/logic/networks.go
@@ -583,7 +583,7 @@ func NetIDInNetworkCharSet(network *models.Network) bool {
 	charset := "abcdefghijklmnopqrstuvwxyz1234567890-_."
 
 	for _, char := range network.NetID {
-		if !strings.Contains(charset, strings.ToLower(string(char))) {
+		if !strings.Contains(charset, string(char)) {
 			return false
 		}
 	}

--- a/netclient/functions/mqhandlers.go
+++ b/netclient/functions/mqhandlers.go
@@ -244,7 +244,7 @@ func setHostDNS(dns, iface string, windows bool) error {
 	if err != nil {
 		return err
 	}
-	profile.Name = iface
+	profile.Name = strings.ToLower(iface)
 	profile.Status = types.Enabled
 	if err := hosts.ReplaceProfile(profile); err != nil {
 		return err
@@ -264,7 +264,7 @@ func removeHostDNS(iface string, windows bool) error {
 	if err != nil {
 		return err
 	}
-	if err := hosts.RemoveProfile(iface); err != nil {
+	if err := hosts.RemoveProfile(strings.ToLower(iface)); err != nil {
 		if err == types.ErrUnknownProfile {
 			return nil
 		}


### PR DESCRIPTION
to test:
create network with Upper case name
check profile in /etc/hosts is created with all lowercase