### PR TITLE
Bugfix v0.14.3 server acl check

### DIFF
--- a/logic/server.go
+++ b/logic/server.go
@@ -215,7 +215,7 @@ func GetServerPeers(serverNode *models.Node) ([]wgtypes.PeerConfig, bool, []stri
 	if err != nil {
 		logger.Log(1, "could not fetch current ACL list, proceeding with all peers")
 	}
-
+	git
 	for _, node := range nodes {
 		pubkey, err := wgtypes.ParseKey(node.PublicKey)
 		if err != nil {
@@ -233,7 +233,7 @@ func GetServerPeers(serverNode *models.Node) ([]wgtypes.PeerConfig, bool, []stri
 				continue
 			}
 		}
-		if currentNetworkACL != nil && currentNetworkACL.IsAllowed(acls.AclID(serverNode.ID), acls.AclID(node.ID)) {
+		if currentNetworkACL != nil && !(currentNetworkACL.IsAllowed(acls.AclID(serverNode.ID), acls.AclID(node.ID))) {
 			continue
 		}
 

--- a/logic/server.go
+++ b/logic/server.go
@@ -215,7 +215,7 @@ func GetServerPeers(serverNode *models.Node) ([]wgtypes.PeerConfig, bool, []stri
 	if err != nil {
 		logger.Log(1, "could not fetch current ACL list, proceeding with all peers")
 	}
-	git
+
 	for _, node := range nodes {
 		pubkey, err := wgtypes.ParseKey(node.PublicKey)
 		if err != nil {


### PR DESCRIPTION
In our testing, this was preventing server peers from being added. However, it has not been a problem till this point and should already be affecting the server in production, so unsure of why this is not always an issue.