### PR TITLE
updating node can wipe traffic keys

### DIFF
--- a/models/node.go
+++ b/models/node.go
@@ -396,6 +396,7 @@ func (newNode *Node) Fill(currentNode *Node) {
 	if newNode.Server == "" {
 		newNode.Server = currentNode.Server
 	}
+	newNode.TrafficKeys = currentNode.TrafficKeys
 }
 
 // StringWithCharset - returns random string inside defined charset


### PR DESCRIPTION
When updating nodes via api (/api/nodes/{network id}/{macaddress}, PUT) if the original traffic keys aren't provided, they are wiped, leaving the server unable to decrypt mq messages from the node.

This retains previous keys regardless if new ones are supplied, as it didn't appear that updating these keys manually to new values is a supported workflow.
