### PR TITLE
Bugfix 0.14.3 for netclient-install.sh on opnsense(FreeBSD)

### DIFF
--- a/netclient/ncutils/netclientutils_freebsd.go
+++ b/netclient/ncutils/netclientutils_freebsd.go
@@ -20,7 +20,7 @@ func RunCmdFormatted(command string, printerr bool) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		logger.Log(0, "error running command: ", command)
-		logger.Log(0, strings.TrimSuffix(string(err), "\n"))
+		logger.Log(0, strings.TrimSuffix(string(out), "\n"))
 	}
 	return string(out), err
 }

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -34,7 +34,7 @@ elif [ -f /etc/arch-release ]; then
 	update_cmd='pacman -Sy'
 	install_cmd='pacman -S --noconfirm'
 elif [ "${OS}" = "FreeBSD" ]; then
-	dependencies="wireguard"
+	dependencies="wireguard wget"
 	update_cmd='pkg update'
 	install_cmd='pkg install -y'
 elif [ -f /etc/openwrt_release ]; then

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -215,8 +215,12 @@ if [ "${KEY}" != "nokey" ]; then
 fi
 
 if [ "${OS}" = "FreeBSD" ]; then
-  echo "Moving netclient executable to \"/usr/sbin/netclient\""
-  mv netclient /usr/sbin  
+  if ! [ -f /usr/sbin/netclient ]; then
+    echo "Moving netclient executable to \"/usr/sbin/netclient\""
+    mv netclient /usr/sbin  
+  else
+    echo "Netclient already present."
+  fi
 fi
 
 if [ "${OS}" = "OpenWRT" ]; then

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -215,7 +215,7 @@ if [ "${KEY}" != "nokey" ]; then
 fi
 
 if [ "${OS}" = "FreeBSD" ]; then
-  if ! [ -x /usr/sbin/netclient ]; then
+  if ! [ -f /usr/sbin/netclient ]; then
     echo "Moving netclient executable to \"/usr/sbin/netclient\""
     mv netclient /usr/sbin  
   else

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -215,7 +215,7 @@ if [ "${KEY}" != "nokey" ]; then
 fi
 
 if [ "${OS}" = "FreeBSD" ]; then
-  if ! [ -f /usr/sbin/netclient ]; then
+  if ! [ -x /usr/sbin/netclient ]; then
     echo "Moving netclient executable to \"/usr/sbin/netclient\""
     mv netclient /usr/sbin  
   else

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -214,6 +214,9 @@ if [ "${KEY}" != "nokey" ]; then
   fi
 fi
 
+if [ "${OS}" = "FreeBSD" ]; then
+  mv netclient /usr/sbin  
+fi
 
 if [ "${OS}" = "OpenWRT" ]; then
 	mv ./netclient /sbin/netclient

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -206,10 +206,12 @@ if [  "${OS}" = "OpenWRT" ]; then
 	EXTRA_ARGS="--daemon=off"
 fi
 
-if [ -z "${NAME}" ]; then
-  ./netclient join -t $KEY $EXTRA_ARGS
-else
-  ./netclient join -t $KEY --name $NAME $EXTRA_ARGS
+if [ "${KEY}" != "nokey" ]; then
+  if [ -z "${NAME}" ]; then
+    ./netclient join -t $KEY $EXTRA_ARGS
+  else
+    ./netclient join -t $KEY --name $NAME $EXTRA_ARGS
+  fi
 fi
 
 

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -215,6 +215,7 @@ if [ "${KEY}" != "nokey" ]; then
 fi
 
 if [ "${OS}" = "FreeBSD" ]; then
+  echo "Moving netclient executable to \"/usr/sbin/netclient\""
   mv netclient /usr/sbin  
 fi
 


### PR DESCRIPTION
### Issues
I ran into issues when using the netclient-install.sh script on opnsense(FreeBSD) according to what the documentation states. [Here is a related issue.](https://github.com/gravitl/netmaker/issues/1149) These changes fix a couple issues;

### Fixes
1. `error decoding token` when running without providing the `KEY` to `netclient-install.sh`. One approach would have been to [update the documentation](https://docs.netmaker.org/netclient.html#freebsd) to inform users to provide the `KEY` same as they do `VERSION`. However, if you just want to install the netclient and not immediately join a network the install script will break with the aforementioned error since `KEY` is set to the string `nokey` and it will try to join a network regardless. I added a check to see if the `KEY` is set to `nokey` ( as it does when one is not provided ). If it's not set, do not try to run `netclient join`.
2. Moving the netclient executable to a directory present on `PATH`.
3. Install `wget` as a dependency as this isn't present by default.

This fix has been tested on a fresh install of `OPNsense 22.1.8_1-amd64` which is built on `FreeBSD 13.0-STABLE`

### Existing bug found, but not corrected.
When first joining a network after installing the netclient on opnesense (or freebsd) with `netclient join -t <token>` you will get an error as it tries to start the service twice. I haven't tracked down what is causing this just yet. It doesn't break anything as you still join the network just fine. There is just unneeded code running trying to start the service multiple times.