### PR TITLE
improve lower-casing for open wrt

### DIFF
--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -114,7 +114,7 @@ dist=netclient
 echo "OS Version = $(uname)"
 echo "Netclient Version = $VERSION"
 
-case $(uname | tr '[:upper:]' '[:lower:]') in
+case $(uname | tr A-Z a-z) in
 	linux*)
 		if [ -z "$CPU_ARCH" ]; then
 			CPU_ARCH=$(uname -m)


### PR DESCRIPTION
fixes an error on OpenWRT

```bash
root@GL-MT1300:~# echo $(uname | tr '[:upper:]' '[:lower:]')
Linlx
root@GL-MT1300:~# echo $(uname | tr A-Z a-z)
linux
```