### PR TITLE
Bugfix v0.14.5 etc hosts lockfile

### DIFF
--- a/netclient/functions/mqhandlers.go
+++ b/netclient/functions/mqhandlers.go
@@ -247,9 +247,10 @@ func UpdatePeers(client mqtt.Client, msg mqtt.Message) {
 func setHostDNS(dns, iface string, windows bool) error {
 	etchosts := "/etc/hosts"
 	temp := os.TempDir()
-	lockfile := temp + "netclient-lock"
+	lockfile := temp + "/netclient-lock"
 	if windows {
 		etchosts = "c:\\windows\\system32\\drivers\\etc\\hosts"
+		lockfile = temp + "\\netclient-lock"
 	}
 	if _, err := os.Stat(lockfile); !errors.Is(err, os.ErrNotExist) {
 		return errors.New("/etc/hosts file is locked .... aborting")

--- a/netclient/functions/mqhandlers.go
+++ b/netclient/functions/mqhandlers.go
@@ -283,9 +283,10 @@ func setHostDNS(dns, iface string, windows bool) error {
 func removeHostDNS(iface string, windows bool) error {
 	etchosts := "/etc/hosts"
 	temp := os.TempDir()
-	lockfile := temp + "netclient-lock"
+	lockfile := temp + "/netclient-lock"
 	if windows {
 		etchosts = "c:\\windows\\system32\\drivers\\etc\\hosts"
+		lockfile = temp + "\\netclient-lock"
 	}
 	if _, err := os.Stat(lockfile); !errors.Is(err, os.ErrNotExist) {
 		return errors.New("/etc/hosts file is locked .... aborting")

--- a/netclient/functions/mqhandlers.go
+++ b/netclient/functions/mqhandlers.go
@@ -2,6 +2,9 @@ package functions
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -243,9 +246,20 @@ func UpdatePeers(client mqtt.Client, msg mqtt.Message) {
 
 func setHostDNS(dns, iface string, windows bool) error {
 	etchosts := "/etc/hosts"
+	temp := os.TempDir()
+	lockfile := temp + "netclient-lock"
 	if windows {
 		etchosts = "c:\\windows\\system32\\drivers\\etc\\hosts"
 	}
+	if _, err := os.Stat(lockfile); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("/etc/hosts file is locked .... aborting")
+	}
+	lock, err := os.Create(lockfile)
+	if err != nil {
+		return fmt.Errorf("could not create lock file %w", err)
+	}
+	lock.Close()
+	defer os.Remove(lockfile)
 	dnsdata := strings.NewReader(dns)
 	profile, err := parser.ParseProfile(dnsdata)
 	if err != nil {
@@ -268,9 +282,20 @@ func setHostDNS(dns, iface string, windows bool) error {
 
 func removeHostDNS(iface string, windows bool) error {
 	etchosts := "/etc/hosts"
+	temp := os.TempDir()
+	lockfile := temp + "netclient-lock"
 	if windows {
 		etchosts = "c:\\windows\\system32\\drivers\\etc\\hosts"
 	}
+	if _, err := os.Stat(lockfile); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("/etc/hosts file is locked .... aborting")
+	}
+	lock, err := os.Create(lockfile)
+	if err != nil {
+		return fmt.Errorf("could not create lock file %w", err)
+	}
+	lock.Close()
+	defer os.Remove(lockfile)
 	hosts, err := file.NewFile(etchosts)
 	if err != nil {
 		return err


### PR DESCRIPTION
running multiple copies of netclient can corrupt /etc/hosts file.  Preventing multiple instances of netclient is not feasible as that would prevent running netclient join/pull/leave/install while netclient daemon is running.

added lockfile as a mutex for access to /etc/hosts  if lockfile exists, dns update is aborted.

to test:
- run multiple copies of netclient daemon and verify /etc/hosts is not corrupted 

  - in particular the part above
```
##################################################################
# Content under this line is handled by hostctl. DO NOT EDIT.
##################################################################


```
should not be updated