### PR TITLE
Fixed by adding validation tags.

### DIFF
--- a/controllers/network_test.go
+++ b/controllers/network_test.go
@@ -223,16 +223,16 @@ func TestValidateNetwork(t *testing.T) {
 				NetID:        "skynet",
 				AddressRange: "10.0.0.256",
 			},
-			errMessage: "Field validation for 'AddressRange' failed on the 'cidr' tag",
+			errMessage: "Field validation for 'AddressRange' failed on the 'cidrv4' tag",
 		},
-		//{
-		//	testname: "InvalidAddress6",
-		//	network: models.Network{
-		//		NetID:         "skynet1",
-		//		AddressRange6: "2607::ffff/130",
-		//	},
-		//	errMessage: "Field validation for 'AddressRange6' failed on the 'cidr' tag",
-		//},
+		{
+			testname: "InvalidAddress6",
+			network: models.Network{
+				NetID:         "skynet1",
+				AddressRange6: "2607::ffff/130",
+			},
+			errMessage: "Field validation for 'AddressRange6' failed on the 'cidrv6' tag",
+		},
 		{
 			testname: "InvalidNetID",
 			network: models.Network{
@@ -287,7 +287,7 @@ func TestValidateNetwork(t *testing.T) {
 			network.SetDefaults()
 			err := logic.ValidateNetwork(&network, false)
 			assert.NotNil(t, err)
-			assert.Contains(t, err.Error(), tc.errMessage)
+			assert.Contains(t, err.Error(), tc.errMessage) // test passes if err.Error() contains the expected errMessage.
 		})
 	}
 }

--- a/models/network.go
+++ b/models/network.go
@@ -7,8 +7,8 @@ import (
 // Network Struct - contains info for a given unique network
 //At  some point, need to replace all instances of Name with something else like  Identifier
 type Network struct {
-	AddressRange        string      `json:"addressrange" bson:"addressrange" validate:"omitempty,cidr"`
-	AddressRange6       string      `json:"addressrange6" bson:"addressrange6"`
+	AddressRange        string      `json:"addressrange" bson:"addressrange" validate:"omitempty,cidrv4"`
+	AddressRange6       string      `json:"addressrange6" bson:"addressrange6" validate:"omitempty,cidrv6"`
 	NetID               string      `json:"netid" bson:"netid" validate:"required,min=1,max=12,netid_valid"`
 	NodesLastModified   int64       `json:"nodeslastmodified" bson:"nodeslastmodified"`
 	NetworkLastModified int64       `json:"networklastmodified" bson:"networklastmodified"`


### PR DESCRIPTION
To test: run go test ./... -test.v (tested with go 1.18.4).