### PR TITLE
fix removal of egress range from relayed egress allowedips

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -418,7 +418,7 @@ func GetPeerUpdateForRelayedNode(node *models.Node, udppeers map[string]string) 
 	//delete egressrange from allowedip if we are egress gateway
 	if node.IsEgressGateway == "yes" {
 		for i := len(allowedips) - 1; i >= 0; i-- {
-			if StringSliceContains(node.EgressGatewayRanges, allowedips[i].IP.String()) {
+			if StringSliceContains(node.EgressGatewayRanges, allowedips[i].String()) {
 				allowedips = append(allowedips[:i], allowedips[i+1:]...)
 			}
 		}


### PR DESCRIPTION
This addresses the issues #1269 and #1243.

According to the comment, the original code was intended to remove a node's own egress ranges from AllowedIPs, to prevent the routing issues seen in the linked issues.

However, the original code compared the egress range in CIDR notation (e.g. `10.10.10.0/24`) against a network prefix (e.g. `10.10.10.0`), since `allowedips[i].IP` only returns the network prefix. This is always false, and the incorrect AllowedIP is never removed.

A quick fix is to convert the entire IPNet to a string, rather than just the prefix. This is what this PR implements.

However, this fix only works when the original egress range is specified in `<network address>/<bits>`. It looks like netmaker currently accepts `<host address>/<bits>` too, e.g. `10.10.10.5/24`, which will not match the already parsed form in allowedips. A more complete fix would have to parse the EgressGatewayRanges and get them into `<network address>/<bits>` form before comparison.