### PR TITLE
Fix: createExtClient()

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -263,6 +263,7 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 	var extclient models.ExtClient
 	extclient.Network = networkName
 	extclient.IngressGatewayID = nodeid
+	extclient.ClientID = params["clientid"]
 	node, err := logic.GetNodeByID(nodeid)
 	if err != nil {
 		logger.Log(0, r.Header.Get("user"),


### PR DESCRIPTION
The clientid supplied in the API call got discarded without ever being used, so createExtClient() could never be used with a custom client-id (until now).
I simply set the matching attribute before passing it to logic.CreateExtClient(), as otherwise it will always receive a blank ClientID & generate one on its own