### PR TITLE
update lastcheckin in addition to lastmodified on node update

### DIFF
--- a/mq/handlers.go
+++ b/mq/handlers.go
@@ -77,6 +77,7 @@ func UpdateNode(client mqtt.Client, msg mqtt.Message) {
 			logger.Log(1, "error unmarshaling payload ", err.Error())
 			return
 		}
+		newNode.SetLastCheckIn()
 		if err := logic.UpdateNode(&currentNode, &newNode); err != nil {
 			logger.Log(1, "error saving node", err.Error())
 			return


### PR DESCRIPTION
[checkintimes.ods](https://github.com/gravitl/netmaker/files/9373844/checkintimes.ods)

If a client node does not receive a node update for itself from the server, the next time it sends a nodeUpdate to the server the last checkin time will be set to the time of the last update from the server.   This checkin time could be far enough in the past such that the UI will display a warning or error for the node, even though the node has completed a check in within the last minute.  see attached file.

the client should not update the lastcheckin time itself as the checkin could fail to reach the server.  Rather that sending periodic node updates from the server, it is easier to update the lastcheckin time as well as the lastmodified time when the server receives a node update from the client. 