### PR TITLE
Refactor 0.15.1 uninstall leave

### DIFF
--- a/netclient/command/commands.go
+++ b/netclient/command/commands.go
@@ -21,7 +21,7 @@ func Join(cfg *config.ClientConfig, privateKey string) error {
 	if err != nil {
 		if !strings.Contains(err.Error(), "ALREADY_INSTALLED") {
 			logger.Log(0, "error installing: ", err.Error())
-			err = functions.WipeLocal(cfg.Network)
+			err = functions.WipeLocal(cfg)
 			if err != nil {
 				logger.Log(1, "error removing artifacts: ", err.Error())
 			}

--- a/netclient/daemon/freebsd.go
+++ b/netclient/daemon/freebsd.go
@@ -108,6 +108,7 @@ func FreebsdDaemon(command string) {
 
 // CleanupFreebsd - removes config files and netclient binary
 func CleanupFreebsd() {
+	ncutils.RunCmd("service netclient stop")
 	RemoveFreebsdDaemon()
 	if err := os.RemoveAll(ncutils.GetNetclientPath()); err != nil {
 		logger.Log(1, "Removing netclient configs: ", err.Error())

--- a/netclient/daemon/freebsd.go
+++ b/netclient/daemon/freebsd.go
@@ -108,7 +108,7 @@ func FreebsdDaemon(command string) {
 
 // CleanupFreebsd - removes config files and netclient binary
 func CleanupFreebsd() {
-	ncutils.RunCmd("service netclient stop")
+	ncutils.RunCmd("service netclient stop", false)
 	RemoveFreebsdDaemon()
 	if err := os.RemoveAll(ncutils.GetNetclientPath()); err != nil {
 		logger.Log(1, "Removing netclient configs: ", err.Error())

--- a/netclient/daemon/systemd.go
+++ b/netclient/daemon/systemd.go
@@ -83,6 +83,9 @@ func RestartSystemD() {
 
 // CleanupLinux - cleans up neclient configs
 func CleanupLinux() {
+	if _, err := ncutils.RunCmd("systemctl stop netclient", false); err != nil {
+		logger.Log(0, "failed to stop netclient service", err.Error())
+	}
 	RemoveSystemDServices()
 	if err := os.RemoveAll(ncutils.GetNetclientPath()); err != nil {
 		logger.Log(1, "Removing netclient configs: ", err.Error())


### PR DESCRIPTION
refactor uninstall & leave:

- delete node from server
- delete wg interface
- delete conf files
- delete dns entries
- delete broker keys if no other networks with that broker
