### PR TITLE
Fix copy paste error

### DIFF
--- a/netclient/wireguard/common.go
+++ b/netclient/wireguard/common.go
@@ -359,7 +359,7 @@ func WriteWgConfig(node *models.Node, privateKey string, peers []wgtypes.PeerCon
 				wireguard.Section(section_interface).Key("PostDown").AddShadow(part)
 			}
 		} else {
-			wireguard.Section(section_interface).Key("PostUp").SetValue((node.PostUp))
+			wireguard.Section(section_interface).Key("PostDown").SetValue((node.PostDown))
 		}
 	}
 	if node.MTU != 0 {


### PR DESCRIPTION
The PostDown section wasn't set anymore in certain cases.

I'm also unsure whether `SetValue` is correct here, as in previous versions that case used `AddShadow(part)` if I understood correctly, which I might not have.