### PR TITLE
additional checks for disconnected nodes

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -61,6 +61,10 @@ func GetPeerUpdate(node *models.Node) (models.PeerUpdate, error) {
 		if node.NetworkSettings.IsPointToSite == "yes" && node.IsHub == "no" && peer.IsHub == "no" {
 			continue
 		}
+		if node.Connected != "yes" {
+			//skip unconnected nodes
+			continue
+		}
 
 		// if the node is not a server, set the endpoint
 		var setEndpoint = !(node.IsServer == "yes")

--- a/netclient/functions/daemon.go
+++ b/netclient/functions/daemon.go
@@ -94,11 +94,13 @@ func startGoRoutines(wg *sync.WaitGroup) context.CancelFunc {
 		cfg := config.ClientConfig{}
 		cfg.Network = network
 		cfg.ReadConfig()
-		if err := wireguard.ApplyConf(&cfg.Node, cfg.Node.Interface, ncutils.GetNetclientPathSpecific()+cfg.Node.Interface+".conf"); err != nil {
-			logger.Log(0, "failed to start ", cfg.Node.Interface, "wg interface", err.Error())
-		}
-		if cfg.PublicIPService != "" {
-			global_settings.PublicIPServices[network] = cfg.PublicIPService
+		if cfg.Node.Connected == "yes" {
+			if err := wireguard.ApplyConf(&cfg.Node, cfg.Node.Interface, ncutils.GetNetclientPathSpecific()+cfg.Node.Interface+".conf"); err != nil {
+				logger.Log(0, "failed to start ", cfg.Node.Interface, "wg interface", err.Error())
+			}
+			if cfg.PublicIPService != "" {
+				global_settings.PublicIPServices[network] = cfg.PublicIPService
+			}
 		}
 
 		server := cfg.Server.Server

--- a/netclient/functions/mqpublish.go
+++ b/netclient/functions/mqpublish.go
@@ -69,41 +69,43 @@ func checkin(currentRun int) {
 			// defaults to iptables for now, may need another default for non-Linux OSes
 			nodeCfg.Node.FirewallInUse = models.FIREWALL_IPTABLES
 		}
-		if nodeCfg.Node.IsStatic != "yes" {
-			extIP, err := ncutils.GetPublicIP(nodeCfg.Server.API)
-			if err != nil {
-				logger.Log(1, "error encountered checking public ip addresses: ", err.Error())
-			}
-			if nodeCfg.Node.Endpoint != extIP && extIP != "" {
-				logger.Log(1, "network:", nodeCfg.Node.Network, "endpoint has changed from ", nodeCfg.Node.Endpoint, " to ", extIP)
-				nodeCfg.Node.Endpoint = extIP
-				if err := PublishNodeUpdate(&nodeCfg); err != nil {
-					logger.Log(0, "network:", nodeCfg.Node.Network, "could not publish endpoint change")
+		if nodeCfg.Node.Connected == "yes" {
+			if nodeCfg.Node.IsStatic != "yes" {
+				extIP, err := ncutils.GetPublicIP(nodeCfg.Server.API)
+				if err != nil {
+					logger.Log(1, "error encountered checking public ip addresses: ", err.Error())
 				}
-			}
-			intIP, err := getPrivateAddr()
-			if err != nil {
-				logger.Log(1, "network:", nodeCfg.Node.Network, "error encountered checking private ip addresses: ", err.Error())
-			}
-			if nodeCfg.Node.LocalAddress != intIP && intIP != "" {
-				logger.Log(1, "network:", nodeCfg.Node.Network, "local Address has changed from ", nodeCfg.Node.LocalAddress, " to ", intIP)
-				nodeCfg.Node.LocalAddress = intIP
-				if err := PublishNodeUpdate(&nodeCfg); err != nil {
-					logger.Log(0, "Network: ", nodeCfg.Node.Network, " could not publish local address change")
+				if nodeCfg.Node.Endpoint != extIP && extIP != "" {
+					logger.Log(1, "network:", nodeCfg.Node.Network, "endpoint has changed from ", nodeCfg.Node.Endpoint, " to ", extIP)
+					nodeCfg.Node.Endpoint = extIP
+					if err := PublishNodeUpdate(&nodeCfg); err != nil {
+						logger.Log(0, "network:", nodeCfg.Node.Network, "could not publish endpoint change")
+					}
 				}
-			}
-			_ = UpdateLocalListenPort(&nodeCfg)
+				intIP, err := getPrivateAddr()
+				if err != nil {
+					logger.Log(1, "network:", nodeCfg.Node.Network, "error encountered checking private ip addresses: ", err.Error())
+				}
+				if nodeCfg.Node.LocalAddress != intIP && intIP != "" {
+					logger.Log(1, "network:", nodeCfg.Node.Network, "local Address has changed from ", nodeCfg.Node.LocalAddress, " to ", intIP)
+					nodeCfg.Node.LocalAddress = intIP
+					if err := PublishNodeUpdate(&nodeCfg); err != nil {
+						logger.Log(0, "Network: ", nodeCfg.Node.Network, " could not publish local address change")
+					}
+				}
+				_ = UpdateLocalListenPort(&nodeCfg)
 
-		} else if nodeCfg.Node.IsLocal == "yes" && nodeCfg.Node.LocalRange != "" {
-			localIP, err := ncutils.GetLocalIP(nodeCfg.Node.LocalRange)
-			if err != nil {
-				logger.Log(1, "network:", nodeCfg.Node.Network, "error encountered checking local ip addresses: ", err.Error())
-			}
-			if nodeCfg.Node.Endpoint != localIP && localIP != "" {
-				logger.Log(1, "network:", nodeCfg.Node.Network, "endpoint has changed from "+nodeCfg.Node.Endpoint+" to ", localIP)
-				nodeCfg.Node.Endpoint = localIP
-				if err := PublishNodeUpdate(&nodeCfg); err != nil {
-					logger.Log(0, "network:", nodeCfg.Node.Network, "could not publish localip change")
+			} else if nodeCfg.Node.IsLocal == "yes" && nodeCfg.Node.LocalRange != "" {
+				localIP, err := ncutils.GetLocalIP(nodeCfg.Node.LocalRange)
+				if err != nil {
+					logger.Log(1, "network:", nodeCfg.Node.Network, "error encountered checking local ip addresses: ", err.Error())
+				}
+				if nodeCfg.Node.Endpoint != localIP && localIP != "" {
+					logger.Log(1, "network:", nodeCfg.Node.Network, "endpoint has changed from "+nodeCfg.Node.Endpoint+" to ", localIP)
+					nodeCfg.Node.Endpoint = localIP
+					if err := PublishNodeUpdate(&nodeCfg); err != nil {
+						logger.Log(0, "network:", nodeCfg.Node.Network, "could not publish localip change")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- do not include disconnected nodes in peers
- do not start wg interface of disconnected nodes
- do not publish public ip, local address, or listen port changes of disconnected nodes.