### PR TITLE
Fix support for armv7l container images

### DIFF
--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -23,6 +23,6 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64, linux/arm64, linux/armv7l
+        platforms: linux/amd64, linux/arm64, linux/arm/v7
         file: ./docker/Dockerfile-go-builder
         tags: gravitl/go-builder:latest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           context: .
           load: true
-          platforms: linux/armv7l
+          platforms: linux/arm/v7
           tags: ${{ env.TAG }}
           build-args: version=${{ env.TAG }}
       -
@@ -89,7 +89,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64, linux/arm64, linux/armv7l
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
           push: true
           tags: ${{ github.repository }}:${{ env.TAG }}, ${{ github.repository }}:latest
           build-args: version=${{ env.TAG }}

--- a/.github/workflows/publish-netclient-docker.yml
+++ b/.github/workflows/publish-netclient-docker.yml
@@ -72,11 +72,27 @@ jobs:
             sleep 10
             kill %1
       -
+        name: Build armv7l and export to Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true
+          platforms: linux/arm/v7
+          file: ./docker/Dockerfile-netclient-multiarch
+          tags: ${{ env.TAG }}
+          build-args: version=${{ env.TAG }}  
+      -
+        name: Test armv7l
+        run: |
+            docker run --rm ${{ env.TAG }}&
+            sleep 10
+            kill %1
+      -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
           file: ./docker/Dockerfile-netclient-multiarch
           push: true
           tags: gravitl/netclient:${{ env.TAG }}, gravitl/netclient:latest


### PR DESCRIPTION
Fixes support for 32bit arm docker images that was initially added with PR #1595 and removed in PR #1656 before release 0.16.1 (I believe due to broken build/publish pipelines).

Incorrect `linux/armv7l` platform was replaced by the correct `linux/arm/v7` platform that should now work