### PR TITLE
Fix netclient breaking when both ingress and egress modes are enabled

### DIFF
--- a/logic/gateway.go
+++ b/logic/gateway.go
@@ -322,7 +322,7 @@ func firewallNFTCommandsCreateIngress(networkInterface string) (string, string) 
 	postUp += "nft add rule ip filter FORWARD oifname " + networkInterface + " counter accept ; "
 	postUp += "nft add table nat ; "
 	postUp += "nft add chain nat postrouting ; "
-	postUp += "nft add rule ip nat postrouting oifname " + networkInterface + " counter masquerade"
+	postUp += "nft add rule ip nat postrouting oifname " + networkInterface + " counter masquerade ; "
 
 	// doesn't remove potentially empty tables or chains
 	postDown := "nft flush table filter ; "


### PR DESCRIPTION
Adds a missing line ending in the postUp masquerade command. This missing line is sneaky, and only seems to pose an issue when both ingress and egress modes are enabled.

The error posed:
```
Oct 18 22:44:22 netclient netclient[13673]: [#] nft add table nat
Oct 18 22:44:22 netclient netclient[13673]: [#] nft add chain nat postrouting
Oct 18 22:44:22 netclient netclient[13673]: [#] nft add rule ip nat postrouting oifname nm-main counter masqueradenft add table ip filter
Oct 18 22:44:22 netclient netclient[13673]: Error: syntax error, unexpected add
Oct 18 22:44:22 netclient netclient[13673]: add rule ip nat postrouting oifname nm-main counter masqueradenft add table ip filter
Oct 18 22:44:22 netclient netclient[13673]:                                                                   ^^^
```

Introduced recently, as things worked great in 0.15.1 and I found this upon upgrading to 0.16.1