### PR TITLE
Adding support for OpenWrt-mips arch

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -306,6 +306,48 @@ jobs:
           prerelease: true
           asset_name: netclient-mipsle
 
+  netclient-mips:
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Variables
+        run: |
+          TAG=${{needs.version.outputs.tag}}
+          VERSION=${{needs.version.outputs.version}}
+          echo "NETMAKER_VERSION=${TAG}"  >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_ENV
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Build
+        run: |
+          cd netclient
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips/netclient main.go
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips-upx/netclient main.go && upx build/netclient-mips-upx/netclient
+
+      - name: Upload mips to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mips/netclient
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mips
+
+      - name: Upload upx compressed version of mips to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mips-upx/netclient
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mips-upx
+
   netclient-freebsd:
     runs-on: ubuntu-latest
     needs: version

--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -20,7 +20,7 @@ function build
 	    build $_goarch $_goose 5 && build $_goarch $_goose 6 && build $_goarch $_goose 7
     else
         echo $_out
-        GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+        if [ "$_goarch" == "mips" ]; then GOMIPS=softfloat; fi; GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
     fi
 }
 

--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -21,6 +21,7 @@ function build
     else
         echo $_out
         if [ "$_goarch" == "mips" ]; then
+            # If the binary created through `GOMIPS=softfloat GOARCH=mipsle` is not compatible with your hardware, try changing these variables and creating a binary file compatible with your hardware.
             GOARM=$_goarm GOMIPS=softfloat GOARCH=mipsle GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
         else
             GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out

--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -20,7 +20,11 @@ function build
 	    build $_goarch $_goose 5 && build $_goarch $_goose 6 && build $_goarch $_goose 7
     else
         echo $_out
-        if [ "$_goarch" == "mips" ]; then GOMIPS=softfloat; fi; GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+        if [ "$_goarch" == "mips" ]; then
+            GOARM=$_goarm GOMIPS=softfloat GOARCH=mipsle GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+        else
+            GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+        fi
     fi
 }
 

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -148,8 +148,11 @@ case $(uname | tr A-Z a-z) in
 			arm*)
 				dist=netclient-$CPU_ARCH
 			;;
-            mipsle)
+			mipsle)
                 dist=netclient-mipsle
+			;;
+			mips*)
+                dist=netclient-$CPU_ARCH
 			;;
 			*)
 				fatal "$CPU_ARCH : cpu architecture not supported"
@@ -240,6 +243,8 @@ if [ "${OS}" = "OpenWRT" ] || [ "${OS}" = "TurrisOS" ]; then
 		else
 			wget $curl_opts -O netclient.service.tmp https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/openwrt-daemon.sh
 		fi
+	elif [ "${OS}" = "OpenWRT" ] && [ "$CPU_ARCH" = "mips" ]; then
+		wget $curl_opts -O netclient.service.tmp https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/openwrt-daemon.sh
 	else
 		cat << 'END_OF_FILE' > ./netclient.service.tmp
 #!/bin/sh /etc/rc.common
@@ -293,4 +298,3 @@ END_OF_FILE
 else 
 	rm -f netclient
 fi
-


### PR DESCRIPTION
netclient/bin-maker.sh:
In [GoMips](https://github.com/golang/go/wiki/GoMips#supported-architectures) MIPS, referred to be "Big endian" architecture and Go build to be created with env `GOMIPS=softfloat`.

scripts/netclient-install.sh:
Modification to install & daemon support for Netclient in Linux environment with MIPS architecture.

`netclient-linux-mips` file generated through `netclient/bin-maker.sh` has been tested through `scripts/netclient-install.sh` in GL-MT1300.

Tested  OpenWrt OS version:
```
OpenWrt 19.07.8
OpenWrt 21.02.5
```

Tested GL-iNet firmware version:
```
stable version: 3.215
beta version: 4.1.0 beta2
```

Tested environment:
```
>> cat /proc/cpuinfo
system type		: MediaTek MT7621 ver:1 eco:3
machine			: GL-MT1300
processor		: 0
cpu model		: MIPS 1004Kc V2.15
BogoMIPS		: 584.90
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 32
extra interrupt vector	: yes
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0ffc, 0x0ffc, 0x0ffb, 0x0ffb]
isa			: mips1 mips2 mips32r1 mips32r2
ASEs implemented	: mips16 dsp mt
Options implemented	: tlb 4kex 4k_cache prefetch mcheck ejtag llsc pinde
```
```
>> uname -a
Linux GL-MT1300 4.14.241 #0 SMP Thu Jul 29 19:50:28 2021 mips GNU/Linux
```
```
cat /etc/os-release
NAME="OpenWrt"
VERSION="19.07.8"
ID="openwrt"
ID_LIKE="lede openwrt"
PRETTY_NAME="OpenWrt 19.07.8"
VERSION_ID="19.07.8"
HOME_URL="https://openwrt.org/"
BUG_URL="https://bugs.openwrt.org/"
SUPPORT_URL="https://forum.openwrt.org/"
BUILD_ID="r11364-ef56c85848"
OPENWRT_BOARD="ramips/mt76x8"
OPENWRT_ARCH="mipsel_24kc"
OPENWRT_TAINTS="busybox"
OPENWRT_DEVICE_MANUFACTURER="OpenWrt"
OPENWRT_DEVICE_MANUFACTURER_URL="https://openwrt.org/"
OPENWRT_DEVICE_PRODUCT="Generic"
OPENWRT_DEVICE_REVISION="v0"
OPENWRT_RELEASE="OpenWrt 19.07.8 r11364-ef56c85848"
```

Note:
Binary generated with `GOMIPS=softfloat GOARCH=mipsle` executed successfully in GL-MT1300 hardware. But however binary file created with environment variables `GOMIPS=softfloat GOARCH=mips` or `GOARCH=mipsle` failed to run in this hardware. 
I don't have devices to test and confirm other OpenWrt architecture.
In the future depending on the hardware additional binary generation and enhancements might occur for the following dist/arch.
```
linux/mips
linux/mips64
linux/mips64le
linux/mipsle
```
