### PR TITLE
don't skip peer if endpoint is the same

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -111,9 +111,6 @@ func GetPeerUpdate(node *models.Node) (models.PeerUpdate, error) {
 				if peer.LocalListenPort != 0 {
 					peer.ListenPort = peer.LocalListenPort
 				}
-			} else {
-				continue
-			}
 		}
 
 		// set address if setEndpoint is true

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -111,6 +111,7 @@ func GetPeerUpdate(node *models.Node) (models.PeerUpdate, error) {
 				if peer.LocalListenPort != 0 {
 					peer.ListenPort = peer.LocalListenPort
 				}
+			}
 		}
 
 		// set address if setEndpoint is true


### PR DESCRIPTION
and can not set endpoint to localaddress