### PR TITLE
Added user FW selection promt Fix for issue #1646

### DIFF
--- a/netclient/functions/join.go
+++ b/netclient/functions/join.go
@@ -277,13 +277,39 @@ func JoinNetwork(cfg *config.ClientConfig, privateKey string) error {
 	}
 
 	if cfg.Node.FirewallInUse == "" {
-		if ncutils.IsNFTablesPresent() {
-			cfg.Node.FirewallInUse = models.FIREWALL_NFTABLES
-		} else if ncutils.IsIPTablesPresent() {
-			cfg.Node.FirewallInUse = models.FIREWALL_IPTABLES
-		} else {
-			cfg.Node.FirewallInUse = models.FIREWALL_NONE
+
+		// If NFTables and IPTables are both present, ask the user to specify which one to use. 
+		// If something else is returned by the user, default to NONE
+		if ncutils.IsNFTablesPresent() && ncutils.IsIPTablesPresent() {
+
+			var fw_to_use string
+
+			logger.Log(0, `Both NFTables and IPTables are installed on this system. Which firewall do you want to configure?
+(1) NFTables
+(2) IPTables`)
+
+			fmt.Scanln(&fw_to_use)
+
+			if fw_to_use == "1" {
+				cfg.Node.FirewallInUse = models.FIREWALL_NFTABLES
+			} else if fw_to_use == "2" {
+				cfg.Node.FirewallInUse = models.FIREWALL_IPTABLES
+			} else {
+				cfg.Node.FirewallInUse = models.FIREWALL_NONE
+			}
+
+		}else{
+
+			if ncutils.IsNFTablesPresent() {
+				cfg.Node.FirewallInUse = models.FIREWALL_NFTABLES
+			} else if ncutils.IsIPTablesPresent() {
+				cfg.Node.FirewallInUse = models.FIREWALL_IPTABLES
+			} else {
+				cfg.Node.FirewallInUse = models.FIREWALL_NONE
+			}
+		
 		}
+
 	}
 
 	// make sure name is appropriate, if not, give blank name


### PR DESCRIPTION
# The problem:
In the current versions of Netclient it is opssible to brick the device when configuring conflicting firewalls to use. For example:
The main FW is IPtables, but NFTables is also installed. Due to the fact that netclient prefers NFTables, there is a situation where the machine would become unresponsive. 

# The solution:
I have added a user promt to fix an issue as described in: [https://github.com/gravitl/netmaker/issues/1646](https://github.com/gravitl/netmaker/issues/1646)

When enrolling a client, using the join command and both NFTables and IPTables are present on the machine, the user will be promted to set their preffered FW to use. 

This promt has 2 options:
(1) NFTables
(2) IPTables

If something else is entered it will default to use FW NONE.

I hope this will save somebody's day.