### PR TITLE
Refactor mqtt to wss

### DIFF
--- a/compose/docker-compose.ee.yml
+++ b/compose/docker-compose.ee.yml
@@ -125,10 +125,10 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.tcp.routers.mqtt.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.tcp.routers.mqtt.tls.certresolver=http
-      - traefik.tcp.services.mqtt.loadbalancer.server.port=8883
-      - traefik.tcp.routers.mqtt.entrypoints=websecure
+      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.tls.certresolver=http
+      - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883
   prometheus:
     container_name: prometheus
     image: gravitl/netmaker-prometheus:latest

--- a/compose/docker-compose.ee.yml
+++ b/compose/docker-compose.ee.yml
@@ -126,7 +126,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.certresolver=http
       - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883
   prometheus:

--- a/compose/docker-compose.ee.yml
+++ b/compose/docker-compose.ee.yml
@@ -125,7 +125,7 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.rule=Host(`broker.NETMAKER_BASE_DOMAIN`)
       - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.certresolver=http
       - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883

--- a/compose/docker-compose.reference.yml
+++ b/compose/docker-compose.reference.yml
@@ -129,11 +129,11 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.tcp.routers.mqtts.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.tcp.routers.mqtts.tls.passthrough=true
-      - traefik.tcp.services.mqtts-svc.loadbalancer.server.port=8883
-      - traefik.tcp.routers.mqtts.service=mqtts-svc
-      - traefik.tcp.routers.mqtts.entrypoints=websecure
+      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.tls.passthrough=true
+      - traefik.http.services.mqtts-svc.loadbalancer.server.port=8883
+      - traefik.http.routers.mqtt_websocket.service=mqtts-svc
 volumes:
   traefik_certs: {} # ssl certificates - auto generated
   shared_certs: {} # netmaker certs generated for MQ comms - used by nodes/servers

--- a/compose/docker-compose.reference.yml
+++ b/compose/docker-compose.reference.yml
@@ -130,7 +130,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.passthrough=true
       - traefik.http.services.mqtts-svc.loadbalancer.server.port=8883
       - traefik.http.routers.mqtt_websocket.service=mqtts-svc

--- a/compose/docker-compose.reference.yml
+++ b/compose/docker-compose.reference.yml
@@ -129,7 +129,7 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.rule=Host(`broker.NETMAKER_BASE_DOMAIN`)
       - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.passthrough=true
       - traefik.http.services.mqtts-svc.loadbalancer.server.port=8883

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.certresolver=http
       - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883
 volumes:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.rule=Host(`broker.NETMAKER_BASE_DOMAIN`)
       - traefik.http.routers.mqtt_websocket.entrypoints=websecure
       - traefik.http.routers.mqtt_websocket.tls.certresolver=http
       - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -122,10 +122,10 @@ services:
       - "8883"
     labels:
       - traefik.enable=true
-      - traefik.tcp.routers.mqtt.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
-      - traefik.tcp.routers.mqtt.tls.certresolver=http
-      - traefik.tcp.services.mqtt.loadbalancer.server.port=8883
-      - traefik.tcp.routers.mqtt.entrypoints=websecure
+      - traefik.http.routers.mqtt_websocket.rule=HostSNI(`broker.NETMAKER_BASE_DOMAIN`)
+      - traefik.http.routers.mqtt_websocket.entrypoints=websocket
+      - traefik.http.routers.mqtt_websocket.tls.certresolver=http
+      - traefik.http.services.mqtt_websocket.loadbalancer.server.port=8883
 volumes:
   traefik_certs: {}
   sqldata: {}

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -4,6 +4,7 @@ protocol websockets
 allow_anonymous false
 
 listener 1883
+protocol websockets
 allow_anonymous false
 
 plugin /usr/lib/mosquitto_dynamic_security.so

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,5 +1,6 @@
 per_listener_settings false
 listener 8883
+protocol websockets
 allow_anonymous false
 
 listener 1883

--- a/netclient/functions/daemon.go
+++ b/netclient/functions/daemon.go
@@ -212,7 +212,7 @@ func setupMQTTSingleton(cfg *config.ClientConfig) error {
 	if err != nil {
 		return fmt.Errorf("could not read secrets file %w", err)
 	}
-	opts.AddBroker("mqtts://" + server + ":" + port)
+	opts.AddBroker("wss://" + server + ":" + port)
 	opts.SetUsername(cfg.Node.ID)
 	opts.SetPassword(string(pass))
 	mqclient = mqtt.NewClient(opts)
@@ -239,7 +239,7 @@ func setupMQTT(cfg *config.ClientConfig) error {
 	if err != nil {
 		return fmt.Errorf("could not read secrets file %w", err)
 	}
-	opts.AddBroker(fmt.Sprintf("mqtts://%s:%s", server, port))
+	opts.AddBroker(fmt.Sprintf("wss://%s:%s", server, port))
 	opts.SetUsername(cfg.Node.ID)
 	opts.SetPassword(string(pass))
 	opts.SetClientID(ncutils.MakeRandomString(23))

--- a/servercfg/serverconf.go
+++ b/servercfg/serverconf.go
@@ -236,6 +236,11 @@ func GetMessageQueueEndpoint() (string, bool) {
 		host = config.Config.Server.MQHOST
 	}
 	secure := strings.Contains(host, "wss") || strings.Contains(host, "ssl")
+	if secure {
+		host = "wss://" + host
+	} else {
+		host = "ws://" + host
+	}
 	return host + ":" + GetMQServerPort(), secure
 }
 

--- a/servercfg/serverconf.go
+++ b/servercfg/serverconf.go
@@ -235,7 +235,7 @@ func GetMessageQueueEndpoint() (string, bool) {
 	} else if config.Config.Server.MQHOST != "" {
 		host = config.Config.Server.MQHOST
 	}
-	secure := strings.Contains(host, "mqtts") || strings.Contains(host, "ssl")
+	secure := strings.Contains(host, "wss") || strings.Contains(host, "ssl")
 	return host + ":" + GetMQServerPort(), secure
 }
 


### PR DESCRIPTION
Dashboard ->  https://dashboard.betmaker.ezflo.in/

Test machine -> `ssh root@139.59.242.82`

With these changes currently the server is unable to connect to the broker
```
[netmaker] 2022-11-10 12:42:17 connecting to mq broker at mq:1883 with TLS? false
[netmaker] Fatal: Admin: could not connect to broker, token timeout, exiting ...
```