### PR TITLE
update to go 1.19

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'main.version=${NETMAKER_VERSION}'" -o build/netmaker main.go
@@ -86,7 +86,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Build cli
         run: |
@@ -190,7 +190,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           cd netclient
@@ -290,7 +290,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           cd netclient
@@ -321,7 +321,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           cd netclient
@@ -363,7 +363,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           cd netclient
@@ -438,7 +438,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
           cd netclient
@@ -491,7 +491,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Mysys2 setup
         uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
          env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build main.go
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: |
          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build mac
         run: |
           env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -tags=gui main.go
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Mysys2 setup
         uses: msys2/setup-msys2@v2
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: run tests
         run: |
             sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GO111MODULE=auto
 RUN apk add git
 RUN GOOS=linux CGO_ENABLED=1 go build ${tags} -ldflags="-s -X 'main.version=${version}'" .
 # RUN go build -tags=ee . -o netmaker main.go
-FROM alpine:3.15.2
+FROM alpine:3.16.2
 
 # add a c lib
 RUN apk add gcompat iptables wireguard-tools

--- a/docker/Dockerfile-go-builder
+++ b/docker/Dockerfile-go-builder
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-alpine3.15 
+FROM golang:1.19-alpine3.16 
 ARG version 
 RUN apk add build-base
 WORKDIR /app

--- a/docker/Dockerfile-netclient-doks
+++ b/docker/Dockerfile-netclient-doks
@@ -3,7 +3,7 @@ FROM debian:buster as builder
 
 RUN apt update -y && apt install -y wget bash gcc musl-dev openssl golang git build-essential libmnl-dev iptables
 
-RUN wget -O go.tgz https://go.dev/dl/go1.18.linux-amd64.tar.gz
+RUN wget -O go.tgz https://go.dev/dl/go1.19.linux-amd64.tar.gz
 
 RUN tar -C /usr/local -xzf go.tgz
 

--- a/docker/Dockerfile-netclient-doks-uspace
+++ b/docker/Dockerfile-netclient-doks-uspace
@@ -3,7 +3,7 @@ FROM debian:buster as builder
 
 RUN apt update -y && apt install -y wget bash gcc musl-dev openssl golang git build-essential libmnl-dev iptables
 
-RUN wget -O go.tgz https://go.dev/dl/go1.18.linux-amd64.tar.gz
+RUN wget -O go.tgz https://go.dev/dl/go1.19.linux-amd64.tar.gz
 
 RUN tar -C /usr/local -xzf go.tgz
 

--- a/docker/Dockerfile-netclient-multiarch
+++ b/docker/Dockerfile-netclient-multiarch
@@ -9,7 +9,7 @@ ENV GO111MODULE=auto
 
 RUN GOOS=linux CGO_ENABLED=0 /usr/local/go/bin/go build -ldflags="-X 'main.version=${version}'" -o netclient-app netclient/main.go
 
-FROM alpine:3.15.2
+FROM alpine:3.16.2
 
 WORKDIR /root/
 

--- a/docker/Dockerfile-netclient-multiarch-userspace
+++ b/docker/Dockerfile-netclient-multiarch-userspace
@@ -24,7 +24,7 @@ RUN git clone https://git.zx2c4.com/wireguard-tools && \
     make && \
     make install
 
-FROM alpine:3.13.6
+FROM alpine:3.16.2
 
 WORKDIR /root/
 

--- a/ee/license.go
+++ b/ee/license.go
@@ -8,7 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 
@@ -200,7 +200,7 @@ func validateLicenseKey(encryptedData []byte, publicKey *[32]byte) ([]byte, erro
 			return nil, fmt.Errorf("could not validate license")
 		} // if you received a 200 cache the response locally
 
-		body, err = ioutil.ReadAll(validateResponse.Body)
+		body, err = io.Copy(validateResponse.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/ee/license.go
+++ b/ee/license.go
@@ -200,7 +200,7 @@ func validateLicenseKey(encryptedData []byte, publicKey *[32]byte) ([]byte, erro
 			return nil, fmt.Errorf("could not validate license")
 		} // if you received a 200 cache the response locally
 
-		body, err = io.Copy(validateResponse.Body)
+		body, err = io.ReadAll(validateResponse.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitl/netmaker
 
-go 1.18
+go 1.19
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2


### PR DESCRIPTION
docker files need to be updated as go-builder is built on golang:1.19-alpine3.16 so base image for netmaker/netclient needs to be updated to apline3.16 as well