### PR TITLE
Fix ipv6 addressing bug

### DIFF
--- a/controllers/network_test.go
+++ b/controllers/network_test.go
@@ -309,7 +309,7 @@ func TestIpv6Network(t *testing.T) {
 	nodeErr := logic.CreateNode(&node1)
 	t.Run("Test node on network IPv6", func(t *testing.T) {
 		assert.Nil(t, nodeErr)
-		assert.Equal(t, "fde6:be04:fa5e:d076::", node1.Address6)
+		assert.Equal(t, "fde6:be04:fa5e:d076::1", node1.Address6)
 	})
 }
 

--- a/logic/networks.go
+++ b/logic/networks.go
@@ -267,14 +267,16 @@ func UniqueAddress6(networkName string, reverse bool) (string, error) {
 		return "666", err
 	}
 	net6 := iplib.Net6FromStr(network.AddressRange6)
-	newAddrs := net6.FirstAddress()
 
+	newAddrs, err := net6.NextIP(net6.FirstAddress())
 	if reverse {
-		newAddrs = net6.LastAddress()
+		newAddrs, err = net6.PreviousIP(net6.LastAddress())
+	}
+	if err != nil {
+		return "", err
 	}
 
 	for {
-
 		if IsIPUnique(networkName, newAddrs.String(), database.NODES_TABLE_NAME, true) &&
 			IsIPUnique(networkName, newAddrs.String(), database.EXT_CLIENT_TABLE_NAME, true) {
 			return newAddrs.String(), nil


### PR DESCRIPTION
Fixes https://github.com/gravitl/netmaker/issues/1679 by changing available IPv6 range to [ (FIRST_IP + 1), (LAST_IP - 1) ]

Testing:-

* https://dashboard.betmaker.ezflo.in
* `ssh root@139.59.242.82` 
