### PR TITLE
Fix #1750 - Lack of fatal error cause output

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func initialize() { // Client Mode Prereq Check
 	}
 
 	if err = database.InitializeDatabase(); err != nil {
-		logger.FatalLog("Error connecting to database")
+		logger.FatalLog("Error connecting to database: ", err.Error())
 	}
 	logger.Log(0, "database successfully connected")
 	if err = logic.AddServerIDIfNotPresent(); err != nil {


### PR DESCRIPTION
### Before

```
[netmaker] 2022-11-19 01:45:22 warning: MASTER_KEY not set, this could make account recovery difficult 
[netmaker] 2022-11-19 01:45:22 connecting to sqlite 
[netmaker] Fatal: Error connecting to database 
```

### After

```
[netmaker] 2022-11-19 01:46:07 warning: MASTER_KEY not set, this could make account recovery difficult 
[netmaker] 2022-11-19 01:46:07 connecting to sqlite 
[netmaker] Fatal: Error connecting to database:  Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub 
```