### PR TITLE
Netclient support for MIPs arch.

### DIFF
--- a/.github/workflows/buildandrelease.yml
+++ b/.github/workflows/buildandrelease.yml
@@ -294,17 +294,48 @@ jobs:
       - name: Build
         run: |
           cd netclient
-          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mipsle/netclient main.go && upx build/netclient-mipsle/netclient
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mipsle/netclient-mipsle main.go && upx -o build/netclient-mipsle/netclient-mipsle-upx build/netclient-mipsle/netclient-mipsle
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mipsle/netclient-mipsle-softfloat main.go && upx -o build/netclient-mipsle/netclient-mipsle-softfloat-upx build/netclient-mipsle/netclient-mipsle-softfloat
 
       - name: Upload mipsle to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: netclient/build/netclient-mipsle/netclient
+          file: netclient/build/netclient-mipsle/netclient-mipsle
           tag: ${{ env.NETMAKER_VERSION }}
           overwrite: true
           prerelease: true
           asset_name: netclient-mipsle
+
+      - name: Upload mipsle-upx to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mipsle/netclient-mipsle-upx
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mipsle-upx
+
+      - name: Upload mipsle-softfloat to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mipsle/netclient-mipsle-softfloat
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mipsle-softfloat
+
+      - name: Upload mipsle-softfloat-upx to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mipsle/netclient-mipsle-softfloat-upx 
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mipsle-softfloat-upx 
 
   netclient-mips:
     runs-on: ubuntu-latest
@@ -325,28 +356,48 @@ jobs:
       - name: Build
         run: |
           cd netclient
-          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips/netclient main.go
-          env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips-upx/netclient main.go && upx build/netclient-mips-upx/netclient
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mips go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips/netclient-mips main.go && upx -o build/netclient-mips/netclient-mips-upx build/netclient-mips/netclient-mips 
+          env CGO_ENABLED=0 GOOS=linux GOARCH=mips GOMIPS=softfloat go build -ldflags "-s -w -X 'main.version=$NETMAKER_VERSION'" -o build/netclient-mips/netclient-mips-softfloat main.go && upx -o build/netclient-mips/netclient-mips-softfloat-upx build/netclient-mips/netclient-mips-softfloat 
 
       - name: Upload mips to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: netclient/build/netclient-mips/netclient
+          file: netclient/build/netclient-mips/netclient-mips
           tag: ${{ env.NETMAKER_VERSION }}
           overwrite: true
           prerelease: true
           asset_name: netclient-mips
 
-      - name: Upload upx compressed version of mips to Release
+      - name: Upload mips-upx to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: netclient/build/netclient-mips-upx/netclient
+          file: netclient/build/netclient-mips/netclient-mips-upx
           tag: ${{ env.NETMAKER_VERSION }}
           overwrite: true
           prerelease: true
           asset_name: netclient-mips-upx
+
+      - name: Upload netclient-mips-softfloat to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mips/netclient-mips-softfloat
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mips-softfloat
+
+      - name: Upload netclient-mips-softfloat-upx to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: netclient/build/netclient-mips/netclient-mips-softfloat-upx
+          tag: ${{ env.NETMAKER_VERSION }}
+          overwrite: true
+          prerelease: true
+          asset_name: netclient-mips-softfloat-upx
 
   netclient-freebsd:
     runs-on: ubuntu-latest

--- a/netclient/bin-maker.sh
+++ b/netclient/bin-maker.sh
@@ -19,11 +19,15 @@ function build
     if [ "$_goarch" == "arm" ] && [ "$_goarm" == "" ]; then
 	    build $_goarch $_goose 5 && build $_goarch $_goose 6 && build $_goarch $_goose 7
     else
-        echo $_out
-        if [ "$_goarch" == "mips" ]; then
-            # If the binary created through `GOMIPS=softfloat GOARCH=mipsle` is not compatible with your hardware, try changing these variables and creating a binary file compatible with your hardware.
-            GOARM=$_goarm GOMIPS=softfloat GOARCH=mipsle GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
+        
+        if [[ $_goarch == mips* ]]; then
+            #At present GOMIPS64 based binaries are not generated through this script, more details about GOMIPS environment variables in https://go.dev/doc/asm#mips .
+            echo $_out-softfloat
+            GOARM=$_goarm GOMIPS=softfloat GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out-softfloat
+            echo $_out
+            GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
         else
+            echo $_out
             GOARM=$_goarm GOARCH=$_goarch GOOS=$_goose GOHOSTARCH=$__HOST_ARCH CGO_ENABLED=0 go build -ldflags="-X 'main.version=$VERSION'" -o $_out
         fi
     fi
@@ -36,4 +40,3 @@ for arch in ${__freebsd[*]}; do build "$arch" "freebsd"; done
 for arch in ${__darwin[*]}; do build "$arch" "darwin"; done
 
 for arch in ${__windows[*]}; do build "$arch" "windows"; done
-

--- a/scripts/netclient-install.sh
+++ b/scripts/netclient-install.sh
@@ -151,8 +151,15 @@ case $(uname | tr A-Z a-z) in
 			mipsle)
                 dist=netclient-mipsle
 			;;
-			mips*)
-                dist=netclient-$CPU_ARCH
+			mips)
+			    #If binary in the below condition is not compatible with your hardware, retry with other netclient-mips* binaries.
+				if [[ `printf '\0\1' | hexdump -e '/2 "%04x"'` -eq 0100 ]]; then
+					#Little Endian, tested and confirmed in GL-MT1300 OS "OpenWrt 19.07.8"
+					dist=netclient-mipsle-softfloat
+				else
+					#Big Endian, tested and confirmed in DSL-2750U OS "OpenWrt 22.03.2"
+					dist=netclient-mips-softfloat
+				fi
 			;;
 			*)
 				fatal "$CPU_ARCH : cpu architecture not supported"


### PR DESCRIPTION
### Netclient binary support for OpenWrt MIPS "Big endian" and "Little endian" architecture. 

### .github/workflows/buildandrelease.yml:
In this pull request following binaries will be created through Go build env `GOMIPS=softfloat`, `GOARCH=mipsle`, `GOARCH=mips`, to support  "Big endian" and "Little endian" architecture go build https://go.dev/doc/asm#mips.

```
netclient-mipsle
netclient-mipsle-upx
netclient-mipsle-softfloat
netclient-mipsle-softfloat-upx
netclient-mips
netclient-mips-upx
netclient-mips-softfloat
netclient-mips-softfloat-upx
```

### scripts/netclient-install.sh:
Modification to install & daemon support for Netclient in Linux environment with MIPS "Big endian" and "Little endian" architecture.

Binary `netclient-mipsle-softfloat` tested in `GL-MT1300` OS `OpenWrt 19.07.8`
Binary `netclient-mips-softfloat` tested in `DSL-2750U` OS `OpenWrt 22.03.2`


Environment of `DSL-2750U`
```
root@OpenWrt:~# lscpu
Architecture:          mips
  Byte Order:          Big Endian
CPU(s):                1
  On-line CPU(s) list: 0
Model:                 Broadcom BMIPS4350 V7.5
Thread(s) per core:    1
Core(s) per socket:    1
Socket(s):             1
BogoMIPS:              319.48
Caches (sum of all):
  L1d:                 32 KiB (1 instance)
  L1i:                 32 KiB (1 instance)
root@OpenWrt:~# cat /proc/cpuinfo
system type		: bcm63xx/96328dg2x2 (0x6328/0xB0)
machine			: D-Link DSL-2750U rev C1
processor		: 0
cpu model		: Broadcom BMIPS4350 V7.5
BogoMIPS		: 319.48
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 32
extra interrupt vector	: yes
hardware watchpoint	: no
isa			: mips1 mips2 mips32r1
ASEs implemented	:
Options implemented	: tlb 4kex 4k_cache prefetch mcheck ejtag llsc dc_aliases
shadow register sets	: 1
kscratch registers	: 0
package			: 0
core			: 0
VCED exceptions		: not available
VCEI exceptions		: not available
```

Environment of `GL-MT1300`
```
root@GL-MT1300:~# lscpu
Architecture:        mips
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  2
Core(s) per socket:  2
Socket(s):           1
BogoMIPS:            584.90
L1d cache:           64 KiB
L1i cache:           64 KiB
L2 cache:            256 KiB
root@GL-MT1300:~# cat /proc/cpuinfo
system type		: MediaTek MT7621 ver:1 eco:3
machine			: GL-MT1300
processor		: 0
cpu model		: MIPS 1004Kc V2.15
BogoMIPS		: 584.90
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 32
extra interrupt vector	: yes
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0ffc, 0x0ffc, 0x0ffb, 0x0ffb]
isa			: mips1 mips2 mips32r1 mips32r2
ASEs implemented	: mips16 dsp mt
Options implemented	: tlb 4kex 4k_cache prefetch mcheck ejtag llsc pindexed_dcache userlocal vint perf_cntr_intr_bit cdmm nan_legacy nan_2008 perf
shadow register sets	: 1
kscratch registers	: 0
package			: 0
core			: 0
VPE			: 0
VCED exceptions		: not available
VCEI exceptions		: not available
```

Note:
Due to hardware limitations binaries `netclient-mipsle-softfloat` and `netclient-mips-softfloat` are tested. 
Depending on the hardware different binary generations and enhancements might occur for the following dist/arch.
```
linux/mips
linux/mips64
linux/mips64le
linux/mipsle
```
If binaries in the release are not supported, generate binaries for various arch through `netclient/bin-maker.sh`

