### PR TITLE
Fixes+Chores: avoid de-referencing nil ptrs + lint

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,17 +3,19 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/oauth2"
 
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/logic"
 	"github.com/gravitl/netmaker/logic/pro/netcache"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/servercfg"
-	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/oauth2"
 )
 
 // == consts ==
@@ -94,12 +96,12 @@ func InitializeAuthProvider() string {
 	return authInfo[0]
 }
 
-// Not included in API reference as part of the OAuth process itself.
 // HandleAuthCallback - handles oauth callback
+// Note: not included in API reference as part of the OAuth process itself.
 func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	if auth_provider == nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintln(w, oauthNotConfigured)
+		_, _ = fmt.Fprintln(w, oauthNotConfigured)
 		return
 	}
 	var functions = getCurrentAuthFunctions()
@@ -108,7 +110,7 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	state, _ := getStateAndCode(r)
 	_, err := netcache.Get(state) // if in netcache proceeed with node registration login
-	if err == nil || len(state) == node_signin_length || (err != nil && strings.Contains(err.Error(), "expired")) {
+	if err == nil || len(state) == node_signin_length || errors.Is(err, netcache.ErrExpired) {
 		logger.Log(0, "proceeding with node SSO callback")
 		HandleNodeSSOCallback(w, r)
 	} else { // handle normal login
@@ -120,10 +122,10 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 //
 // Handles OAuth login.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 func HandleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if auth_provider == nil {
 		var referer = r.Header.Get("referer")
@@ -132,7 +134,7 @@ func HandleAuthLogin(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintln(w, oauthNotConfigured)
+		_, _ = fmt.Fprintln(w, oauthNotConfigured)
 		return
 	}
 	var functions = getCurrentAuthFunctions()

--- a/controllers/ipservice.go
+++ b/controllers/ipservice.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+
 	"github.com/gravitl/netmaker/netclient/ncutils"
 )
 
@@ -18,33 +19,31 @@ func ipHandlers(r *mux.Router) {
 //
 // Get the current public IP address.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: byteArrayResponse
-//
+//			Responses:
+//				200: byteArrayResponse
 func getPublicIP(w http.ResponseWriter, r *http.Request) {
 	r.Header.Set("Connection", "close")
 	ip, err := parseIP(r)
 	if err != nil {
 		w.WriteHeader(400)
-		if ip != "" {
-			w.Write([]byte("ip is invalid: " + ip))
-			return
-		} else {
-			w.Write([]byte("no ip found"))
-			return
-		}
-	} else {
-		if err != nil {
+		switch {
+		case ip != "":
+			_, _ = w.Write([]byte("ip is invalid: " + ip))
+		case ip == "":
+			_, _ = w.Write([]byte("no ip found"))
+		default:
 			fmt.Println(err)
 		}
+		return
 	}
+
 	w.WriteHeader(200)
-	w.Write([]byte(ip))
+	_, _ = w.Write([]byte(ip))
 }
 
 func parseIP(r *http.Request) (string, error) {

--- a/controllers/network.go
+++ b/controllers/network.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+
 	"github.com/gravitl/netmaker/database"
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/logic"
@@ -36,13 +37,13 @@ func networkHandlers(r *mux.Router) {
 //
 // Lists all networks.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: getNetworksSliceResponse
+//			Responses:
+//				200: getNetworksSliceResponse
 func getNetworks(w http.ResponseWriter, r *http.Request) {
 
 	headerNetworks := r.Header.Get("networks")
@@ -87,13 +88,13 @@ func getNetworks(w http.ResponseWriter, r *http.Request) {
 //
 // Get a network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: networkBodyResponse
+//			Responses:
+//				200: networkBodyResponse
 func getNetwork(w http.ResponseWriter, r *http.Request) {
 	// set header.
 	w.Header().Set("Content-Type", "application/json")
@@ -118,13 +119,13 @@ func getNetwork(w http.ResponseWriter, r *http.Request) {
 //
 // Update keys for a network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: networkBodyResponse
+//			Responses:
+//				200: networkBodyResponse
 func keyUpdate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
@@ -158,13 +159,13 @@ func keyUpdate(w http.ResponseWriter, r *http.Request) {
 //
 // Update a network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: networkBodyResponse
+//			Responses:
+//				200: networkBodyResponse
 func updateNetwork(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
@@ -281,13 +282,13 @@ func updateNetwork(w http.ResponseWriter, r *http.Request) {
 //
 // Update a network ACL (Access Control List).
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: aclContainerResponse
+//			Responses:
+//				200: aclContainerResponse
 func updateNetworkACL(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
@@ -339,13 +340,13 @@ func updateNetworkACL(w http.ResponseWriter, r *http.Request) {
 //
 // Get a network ACL (Access Control List).
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: aclContainerResponse
+//			Responses:
+//				200: aclContainerResponse
 func getNetworkACL(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
@@ -367,13 +368,13 @@ func getNetworkACL(w http.ResponseWriter, r *http.Request) {
 //
 // Delete a network.  Will not delete if there are any nodes that belong to the network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: stringJSONResponse
+//			Responses:
+//				200: stringJSONResponse
 func deleteNetwork(w http.ResponseWriter, r *http.Request) {
 	// Set header
 	w.Header().Set("Content-Type", "application/json")
@@ -414,13 +415,13 @@ func deleteNetwork(w http.ResponseWriter, r *http.Request) {
 //
 // Create a network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: networkBodyResponse
+//			Responses:
+//				200: networkBodyResponse
 func createNetwork(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
@@ -463,18 +464,14 @@ func createNetwork(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	if err := mq.PublishEventToDynSecTopic(event); err != nil {
+	if err = mq.PublishEventToDynSecTopic(event); err != nil {
 		logger.Log(0, fmt.Sprintf("failed to send DynSec command [%v]: %v",
 			event.Commands, err.Error()))
 	}
 
 	if servercfg.IsClientMode() != "off" {
-		_, err := logic.ServerJoin(&network)
-		if err != nil {
-			logic.DeleteNetwork(network.NetID)
-			if err == nil {
-				err = errors.New("Failed to add server to network " + network.NetID)
-			}
+		if _, err = logic.ServerJoin(&network); err != nil {
+			_ = logic.DeleteNetwork(network.NetID)
 			logger.Log(0, r.Header.Get("user"), "failed to create network: ",
 				err.Error())
 			logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
@@ -491,20 +488,20 @@ func createNetwork(w http.ResponseWriter, r *http.Request) {
 //
 // Create a network access key.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: accessKeyBodyResponse
+//			Responses:
+//				200: accessKeyBodyResponse
 //
 // BEGIN KEY MANAGEMENT SECTION
 func createAccessKey(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
 	var accesskey models.AccessKey
-	//start here
+	// start here
 	netname := params["networkname"]
 	network, err := logic.GetParentNetwork(netname)
 	if err != nil {
@@ -545,13 +542,13 @@ func createAccessKey(w http.ResponseWriter, r *http.Request) {
 //
 // Get network access keys for a network.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200: accessKeySliceBodyResponse
+//			Responses:
+//				200: accessKeySliceBodyResponse
 func getAccessKeys(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var params = mux.Vars(r)
@@ -575,14 +572,14 @@ func getAccessKeys(w http.ResponseWriter, r *http.Request) {
 //
 // Delete a network access key.
 //
-//		Schemes: https
+//			Schemes: https
 //
-// 		Security:
-//   		oauth
+//			Security:
+//	  		oauth
 //
-//		Responses:
-//			200:
-//			*: stringJSONResponse
+//			Responses:
+//				200:
+//				*: stringJSONResponse
 //
 // delete key. Has to do a little funky logic since it's not a collection item
 func deleteAccessKey(w http.ResponseWriter, r *http.Request) {

--- a/logic/gateway.go
+++ b/logic/gateway.go
@@ -47,7 +47,7 @@ func CreateEgressGateway(gateway models.EgressGatewayRequest) (models.Node, erro
 	postUpCmd := ""
 	postDownCmd := ""
 	ipv4, ipv6 := getNetworkProtocols(gateway.Ranges)
-	//no support for ipv6 and ip6tables in netmaker container
+	// no support for ipv6 and ip6tables in netmaker container
 	if node.IsServer == "yes" {
 		ipv6 = false
 	}
@@ -181,15 +181,16 @@ func CreateIngressGateway(netid string, nodeid string, failover bool) (models.No
 
 	var postUpCmd, postDownCmd string
 	node, err := GetNodeByID(nodeid)
+
+	if err != nil {
+		return models.Node{}, err
+	}
+
 	if node.OS != "linux" { // add in darwin later
 		return models.Node{}, errors.New(node.OS + " is unsupported for ingress gateways")
 	}
 	if node.OS == "linux" && node.FirewallInUse == models.FIREWALL_NONE {
 		return models.Node{}, errors.New("firewall is not supported for ingress gateways")
-	}
-
-	if err != nil {
-		return models.Node{}, err
 	}
 
 	network, err := GetParentNetwork(netid)
@@ -203,7 +204,7 @@ func CreateIngressGateway(netid string, nodeid string, failover bool) (models.No
 	node.IngressGatewayRange = network.AddressRange
 	node.IngressGatewayRange6 = network.AddressRange6
 	ipv4, ipv6 := getNetworkProtocols(cidrs)
-	//no support for ipv6 and ip6tables in netmaker container
+	// no support for ipv6 and ip6tables in netmaker container
 	if node.IsServer == "yes" {
 		ipv6 = false
 	}

--- a/logic/jwts.go
+++ b/logic/jwts.go
@@ -118,7 +118,7 @@ func VerifyUserToken(tokenString string) (username string, networks []string, is
 		// check that user exists
 		user, err = GetUser(claims.UserName)
 		if err != nil {
-			return "", nil, false, errors.New("user does not exist")
+			return "", nil, false, err
 		}
 
 		if user.UserName != "" {

--- a/logic/jwts.go
+++ b/logic/jwts.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/servercfg"
@@ -100,7 +101,7 @@ func CreateUserJWT(username string, networks []string, isadmin bool) (response s
 	return "", err
 }
 
-// VerifyToken func will used to Verify the JWT Token while using APIS
+// VerifyUserToken func will used to Verify the JWT Token while using APIS
 func VerifyUserToken(tokenString string) (username string, networks []string, isadmin bool, err error) {
 	claims := &models.UserClaims{}
 
@@ -113,8 +114,14 @@ func VerifyUserToken(tokenString string) (username string, networks []string, is
 	})
 
 	if token != nil && token.Valid {
+		var user models.User
 		// check that user exists
-		if user, err := GetUser(claims.UserName); user.UserName != "" && err == nil {
+		user, err = GetUser(claims.UserName)
+		if err != nil {
+			return "", nil, false, errors.New("user does not exist")
+		}
+
+		if user.UserName != "" {
 			return claims.UserName, claims.Networks, claims.IsAdmin, nil
 		}
 		err = errors.New("user does not exist")
@@ -126,8 +133,8 @@ func VerifyUserToken(tokenString string) (username string, networks []string, is
 func VerifyToken(tokenString string) (nodeID string, mac string, network string, err error) {
 	claims := &models.Claims{}
 
-	//this may be a stupid way of serving up a master key
-	//TODO: look into a different method. Encryption?
+	// this may be a stupid way of serving up a master key
+	// TODO: look into a different method. Encryption?
 	if tokenString == servercfg.GetMasterKey() && servercfg.GetMasterKey() != "" {
 		return "mastermac", "", "", nil
 	}

--- a/logic/pro/netcache/netcache.go
+++ b/logic/pro/netcache/netcache.go
@@ -21,7 +21,7 @@ type CValue struct {
 	Expiration time.Time `json:"expiration"`
 }
 
-var errExpired = fmt.Errorf("expired")
+var ErrExpired = fmt.Errorf("expired")
 
 // Set - sets a value to a key in db
 func Set(k string, newValue *CValue) error {
@@ -45,7 +45,7 @@ func Get(k string) (*CValue, error) {
 		return nil, err
 	}
 	if time.Now().After(entry.Expiration) {
-		return nil, errExpired
+		return nil, ErrExpired
 	}
 
 	return &entry, nil

--- a/netclient/daemon/common.go
+++ b/netclient/daemon/common.go
@@ -14,10 +14,10 @@ import (
 // InstallDaemon - Calls the correct function to install the netclient as a daemon service on the given operating system.
 func InstallDaemon() error {
 
-	os := runtime.GOOS
+	runtimeOS := runtime.GOOS
 	var err error
 
-	switch os {
+	switch runtimeOS {
 	case "windows":
 		err = SetupWindowsDaemon()
 	case "darwin":
@@ -54,9 +54,9 @@ func Restart() error {
 
 // Start - starts system daemon
 func Start() error {
-	os := runtime.GOOS
+	runtimeOS := runtime.GOOS
 	var err error
-	switch os {
+	switch runtimeOS {
 	case "windows":
 		RestartWindowsDaemon()
 	case "darwin":
@@ -73,12 +73,12 @@ func Start() error {
 
 // Stop - stops a system daemon
 func Stop() error {
-	os := runtime.GOOS
+	runtimeOS := runtime.GOOS
 	var err error
 
 	time.Sleep(time.Second)
 
-	switch os {
+	switch runtimeOS {
 	case "windows":
 		RunWinSWCMD("stop")
 	case "darwin":

--- a/netclient/functions/common.go
+++ b/netclient/functions/common.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.zx2c4.com/wireguard/wgctrl"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/config"
@@ -22,7 +24,6 @@ import (
 	"github.com/gravitl/netmaker/netclient/local"
 	"github.com/gravitl/netmaker/netclient/ncutils"
 	"github.com/gravitl/netmaker/netclient/wireguard"
-	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
 // LINUX_APP_DATA_PATH - linux path
@@ -61,27 +62,27 @@ func ListPorts() error {
 
 func getPrivateAddr() (string, error) {
 
-	var local string
+	var localIPStr string
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err == nil {
 		defer conn.Close()
 
 		localAddr := conn.LocalAddr().(*net.UDPAddr)
 		localIP := localAddr.IP
-		local = localIP.String()
+		localIPStr = localIP.String()
 	}
-	if local == "" {
-		local, err = getPrivateAddrBackup()
+	if localIPStr == "" {
+		localIPStr, err = getPrivateAddrBackup()
 	}
 
-	if local == "" {
+	if localIPStr == "" {
 		err = errors.New("could not find local ip")
 	}
-	if net.ParseIP(local).To16() != nil {
-		local = "[" + local + "]"
+	if net.ParseIP(localIPStr).To16() != nil {
+		localIPStr = "[" + localIPStr + "]"
 	}
 
-	return local, err
+	return localIPStr, err
 }
 
 func getPrivateAddrBackup() (string, error) {

--- a/netclient/functions/list.go
+++ b/netclient/functions/list.go
@@ -6,11 +6,12 @@ import (
 	"io"
 	"net/http"
 
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/config"
 	"github.com/gravitl/netmaker/netclient/ncutils"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // Peer - the peer struct for list
@@ -77,11 +78,11 @@ func getNetwork(network string) (Network, error) {
 	if err != nil {
 		return Network{}, fmt.Errorf("reading configuration for network %v: %w", network, err)
 	}
-	//peers, err := getPeers(network)
+	// peers, err := getPeers(network)
 	peers := []Peer{}
-	if err != nil {
+	/*	if err != nil {
 		return Network{}, fmt.Errorf("listing peers for network %v: %w", network, err)
-	}
+	}*/
 	return Network{
 		Name:  network,
 		ID:    cfg.Node.ID,

--- a/netclient/functions/localport.go
+++ b/netclient/functions/localport.go
@@ -1,16 +1,16 @@
 //go:build !freebsd
-// +build !freebsd
 
 package functions
 
 import (
 	"strconv"
 
+	"golang.zx2c4.com/wireguard/wgctrl"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/netclient/config"
 	"github.com/gravitl/netmaker/netclient/local"
 	"github.com/gravitl/netmaker/netclient/ncutils"
-	"golang.zx2c4.com/wireguard/wgctrl"
 )
 
 // GetLocalListenPort - Gets the port running on the local interface

--- a/netclient/functions/mqhandlers.go
+++ b/netclient/functions/mqhandlers.go
@@ -11,23 +11,24 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/guumaster/hostctl/pkg/file"
+	"github.com/guumaster/hostctl/pkg/parser"
+	"github.com/guumaster/hostctl/pkg/types"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/config"
 	"github.com/gravitl/netmaker/netclient/local"
 	"github.com/gravitl/netmaker/netclient/ncutils"
 	"github.com/gravitl/netmaker/netclient/wireguard"
-	"github.com/guumaster/hostctl/pkg/file"
-	"github.com/guumaster/hostctl/pkg/parser"
-	"github.com/guumaster/hostctl/pkg/types"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // All -- mqtt message hander for all ('#') topics
 var All mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
 	logger.Log(0, "default message handler -- received message but not handling")
 	logger.Log(0, "topic: "+string(msg.Topic()))
-	//logger.Log(0, "Message: " + string(msg.Payload()))
+	// logger.Log(0, "Message: " + string(msg.Payload()))
 }
 
 // NodeUpdate -- mqtt message handler for /update/<NodeID> topic
@@ -107,7 +108,7 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 		logger.Log(0, "error reading PrivateKey "+err.Error())
 		return
 	}
-	file := ncutils.GetNetclientPathSpecific() + nodeCfg.Node.Interface + ".conf"
+	cfgFile := ncutils.GetNetclientPathSpecific() + nodeCfg.Node.Interface + ".conf"
 
 	if newNode.ListenPort != nodeCfg.Node.LocalListenPort {
 		if err := wireguard.RemoveConf(newNode.Interface, false); err != nil {
@@ -121,15 +122,15 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 		ifaceDelta = true
 		informPortChange(&newNode)
 	}
-	if err := wireguard.UpdateWgInterface(file, privateKey, nameserver, newNode); err != nil {
+	if err := wireguard.UpdateWgInterface(cfgFile, privateKey, nameserver, newNode); err != nil {
 		logger.Log(0, "error updating wireguard config "+err.Error())
 		return
 	}
 	if keepaliveChange {
-		wireguard.UpdateKeepAlive(file, newNode.PersistentKeepalive)
+		wireguard.UpdateKeepAlive(cfgFile, newNode.PersistentKeepalive)
 	}
-	logger.Log(0, "applying WG conf to "+file)
-	err = wireguard.ApplyConf(&nodeCfg.Node, nodeCfg.Node.Interface, file)
+	logger.Log(0, "applying WG conf to "+cfgFile)
+	err = wireguard.ApplyConf(&nodeCfg.Node, nodeCfg.Node.Interface, cfgFile)
 	if err != nil {
 		logger.Log(0, "error restarting wg after node update -", err.Error())
 		return
@@ -159,7 +160,7 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 			logger.Log(0, "network:", nodeCfg.Node.Network, "signalled finished hub update to server")
 		}
 	}
-	//deal with DNS
+	// deal with DNS
 	if newNode.DNSOn != "yes" && shouldDNSChange && nodeCfg.Node.Interface != "" {
 		logger.Log(0, "network:", nodeCfg.Node.Network, "settng DNS off")
 		if err := removeHostDNS(nodeCfg.Node.Interface, ncutils.IsWindows()); err != nil {
@@ -205,13 +206,13 @@ func UpdatePeers(client mqtt.Client, msg mqtt.Message) {
 		cfg.Server.Version = peerUpdate.ServerVersion
 		config.Write(&cfg, cfg.Network)
 	}
-	file := ncutils.GetNetclientPathSpecific() + cfg.Node.Interface + ".conf"
-	internetGateway, err := wireguard.UpdateWgPeers(file, peerUpdate.Peers)
+	cfgFile := ncutils.GetNetclientPathSpecific() + cfg.Node.Interface + ".conf"
+	internetGateway, err := wireguard.UpdateWgPeers(cfgFile, peerUpdate.Peers)
 	if err != nil {
 		logger.Log(0, "error updating wireguard peers"+err.Error())
 		return
 	}
-	//check if internet gateway has changed
+	// check if internet gateway has changed
 	oldGateway, err := net.ResolveUDPAddr("udp", cfg.Node.InternetGateway)
 
 	// note: may want to remove second part (oldGateway == &net.UDPAddr{})
@@ -224,7 +225,7 @@ func UpdatePeers(client mqtt.Client, msg mqtt.Message) {
 		if err := config.ModNodeConfig(&cfg.Node); err != nil {
 			logger.Log(0, "failed to save internet gateway", err.Error())
 		}
-		if err := wireguard.ApplyConf(&cfg.Node, cfg.Node.Interface, file); err != nil {
+		if err := wireguard.ApplyConf(&cfg.Node, cfg.Node.Interface, cfgFile); err != nil {
 			logger.Log(0, "error applying internet gateway", err.Error())
 		}
 		UpdateLocalListenPort(&cfg)
@@ -232,7 +233,7 @@ func UpdatePeers(client mqtt.Client, msg mqtt.Message) {
 	}
 	queryAddr := cfg.Node.PrimaryAddress()
 
-	//err = wireguard.SyncWGQuickConf(cfg.Node.Interface, file)
+	// err = wireguard.SyncWGQuickConf(cfg.Node.Interface, file)
 	var iface = cfg.Node.Interface
 	if ncutils.IsMac() {
 		iface, err = local.GetMacIface(queryAddr)

--- a/netclient/functions/mqpublish.go
+++ b/netclient/functions/mqpublish.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cloverstd/tcping/ping"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/logic/metrics"
 	"github.com/gravitl/netmaker/models"
@@ -105,7 +106,7 @@ func checkin() {
 				}
 			}
 		}
-		//check version
+		// check version
 		if nodeCfg.Node.Version != ncutils.Version {
 			nodeCfg.Node.Version = ncutils.Version
 			config.Write(&nodeCfg, nodeCfg.Network)
@@ -193,15 +194,16 @@ func publishMetrics(nodeCfg *config.ClientConfig) {
 		return
 	}
 
-	metrics, err := metrics.Collect(nodeCfg.Node.Interface, nodeGET.PeerIDs)
+	collected, err := metrics.Collect(nodeCfg.Node.Interface, nodeGET.PeerIDs)
 	if err != nil {
 		logger.Log(0, "failed metric collection for node", nodeCfg.Node.Name, err.Error())
+		return
 	}
-	metrics.Network = nodeCfg.Node.Network
-	metrics.NodeName = nodeCfg.Node.Name
-	metrics.NodeID = nodeCfg.Node.ID
-	metrics.IsServer = "no"
-	data, err := json.Marshal(metrics)
+	collected.Network = nodeCfg.Node.Network
+	collected.NodeName = nodeCfg.Node.Name
+	collected.NodeID = nodeCfg.Node.ID
+	collected.IsServer = "no"
+	data, err := json.Marshal(collected)
 	if err != nil {
 		logger.Log(0, "something went wrong when marshalling metrics data for node", nodeCfg.Node.Name, err.Error())
 	}
@@ -217,15 +219,15 @@ func publishMetrics(nodeCfg *config.ClientConfig) {
 			err = json.Unmarshal(val.([]byte), &oldMetrics)
 			if err == nil {
 				for k := range oldMetrics.Connectivity {
-					currentMetric := metrics.Connectivity[k]
+					currentMetric := collected.Connectivity[k]
 					if currentMetric.Latency == 0 {
 						currentMetric.Latency = oldMetrics.Connectivity[k].Latency
 					}
 					currentMetric.Uptime += oldMetrics.Connectivity[k].Uptime
 					currentMetric.TotalTime += oldMetrics.Connectivity[k].TotalTime
-					metrics.Connectivity[k] = currentMetric
+					collected.Connectivity[k] = currentMetric
 				}
-				newData, err := json.Marshal(metrics)
+				newData, err := json.Marshal(collected)
 				if err == nil {
 					metricsCache.Store(nodeCfg.Node.ID, newData)
 				}

--- a/netclient/local/local.go
+++ b/netclient/local/local.go
@@ -1,7 +1,7 @@
 package local
 
 import (
-	//"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 	"errors"
 	"log"
 	"net"
@@ -15,9 +15,9 @@ import (
 
 // SetIPForwarding - Sets IP forwarding if it's mac or linux
 func SetIPForwarding() error {
-	os := runtime.GOOS
+	runtimeOS := runtime.GOOS
 	var err error
-	switch os {
+	switch runtimeOS {
 	case "linux":
 		err = SetIPForwardingUnix()
 	case "freebsd":

--- a/netclient/ncutils/netclientutils.go
+++ b/netclient/ncutils/netclientutils.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/c-robinson/iplib"
+
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/global_settings"
@@ -131,9 +132,9 @@ func IsIPTablesPresent() bool {
 
 // IsKernel - checks if running kernel WireGuard
 func IsKernel() bool {
-	//TODO
-	//Replace && true with some config file value
-	//This value should be something like kernelmode, which should be 'on' by default.
+	// TODO
+	// Replace && true with some config file value
+	// This value should be something like kernelmode, which should be 'on' by default.
 	return IsLinux() && os.Getenv("WG_QUICK_USERSPACE_IMPLEMENTATION") == ""
 }
 
@@ -161,19 +162,32 @@ func GetPublicIP(api string) (string, error) {
 		iplist = append([]string{api}, iplist...)
 	}
 
+	var bodies []*http.Response
+	defer func() {
+		for _, res := range bodies {
+			if res != nil {
+				_ = res.Body.Close()
+			}
+		}
+	}()
+
 	endpoint := ""
 	var err error
 	for _, ipserver := range iplist {
 		client := &http.Client{
 			Timeout: time.Second * 10,
 		}
-		resp, err := client.Get(ipserver)
+
+		var resp *http.Response
+		resp, err = client.Get(ipserver)
 		if err != nil {
 			continue
 		}
-		defer resp.Body.Close()
+
+		bodies = append(bodies, resp)
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err := io.ReadAll(resp.Body)
+			var bodyBytes []byte
+			bodyBytes, err = io.ReadAll(resp.Body)
 			if err != nil {
 				continue
 			}
@@ -259,7 +273,7 @@ func GetNetworkIPMask(networkstring string) (string, string, error) {
 	ipstring := ip.String()
 	mask := ipnet.Mask
 	maskstring := fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
-	//maskstring := ipnet.Mask.String()
+	// maskstring := ipnet.Mask.String()
 	return ipstring, maskstring, err
 }
 
@@ -437,7 +451,7 @@ func Copy(src, dst string) error {
 func RunCmds(commands []string, printerr bool) error {
 	var err error
 	for _, command := range commands {
-		//prevent panic
+		// prevent panic
 		if len(strings.Trim(command, " ")) == 0 {
 			continue
 		}
@@ -474,7 +488,7 @@ func GetSystemNetworks() ([]string, error) {
 		return nil, err
 	}
 	for _, file := range files {
-		//don't want files such as *.bak, *.swp
+		// don't want files such as *.bak, *.swp
 		if filepath.Ext(file) != "" {
 			continue
 		}

--- a/netclient/ncutils/netclientutils.go
+++ b/netclient/ncutils/netclientutils.go
@@ -162,29 +162,18 @@ func GetPublicIP(api string) (string, error) {
 		iplist = append([]string{api}, iplist...)
 	}
 
-	var bodies []*http.Response
-	defer func() {
-		for _, res := range bodies {
-			if res != nil {
-				_ = res.Body.Close()
-			}
-		}
-	}()
-
 	endpoint := ""
 	var err error
 	for _, ipserver := range iplist {
 		client := &http.Client{
 			Timeout: time.Second * 10,
 		}
-
 		var resp *http.Response
 		resp, err = client.Get(ipserver)
 		if err != nil {
 			continue
 		}
-
-		bodies = append(bodies, resp)
+		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
 			var bodyBytes []byte
 			bodyBytes, err = io.ReadAll(resp.Body)

--- a/serverctl/serverctl.go
+++ b/serverctl/serverctl.go
@@ -127,21 +127,21 @@ func setNetworkDefaults() error {
 	if err != nil && !database.IsEmptyRecord(err) {
 		return err
 	}
-	for _, net := range networks {
-		if err = pro.InitializeNetworkUsers(net.NetID); err != nil {
-			logger.Log(0, "could not initialize NetworkUsers on network", net.NetID)
+	for _, network := range networks {
+		if err = pro.InitializeNetworkUsers(network.NetID); err != nil {
+			logger.Log(0, "could not initialize NetworkUsers on network", network.NetID)
 		}
-		pro.AddProNetDefaults(&net)
+		pro.AddProNetDefaults(&network)
 		update := false
-		newNet := net
-		if strings.Contains(net.NetID, ".") {
-			newNet.NetID = strings.ReplaceAll(net.NetID, ".", "")
-			newNet.DefaultInterface = strings.ReplaceAll(net.DefaultInterface, ".", "")
+		newNet := network
+		if strings.Contains(network.NetID, ".") {
+			newNet.NetID = strings.ReplaceAll(network.NetID, ".", "")
+			newNet.DefaultInterface = strings.ReplaceAll(network.DefaultInterface, ".", "")
 			update = true
 		}
-		if strings.ContainsAny(net.NetID, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
-			newNet.NetID = strings.ToLower(net.NetID)
-			newNet.DefaultInterface = strings.ToLower(net.DefaultInterface)
+		if strings.ContainsAny(network.NetID, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+			newNet.NetID = strings.ToLower(network.NetID)
+			newNet.DefaultInterface = strings.ToLower(network.DefaultInterface)
 			update = true
 		}
 		if update {
@@ -149,14 +149,14 @@ func setNetworkDefaults() error {
 			if err := logic.SaveNetwork(&newNet); err != nil {
 				logger.Log(0, "error saving networks during initial update:", err.Error())
 			}
-			if err := logic.DeleteNetwork(net.NetID); err != nil {
+			if err := logic.DeleteNetwork(network.NetID); err != nil {
 				logger.Log(0, "error deleting old network:", err.Error())
 			}
 		} else {
-			net.SetDefaults()
-			_, _, _, _, _, _, err = logic.UpdateNetwork(&net, &net)
+			network.SetDefaults()
+			_, _, _, _, _, _, err = logic.UpdateNetwork(&network, &network)
 			if err != nil {
-				logger.Log(0, "could not set defaults on network", net.NetID)
+				logger.Log(0, "could not set defaults on network", network.NetID)
 			}
 		}
 	}

--- a/test/main.go
+++ b/test/main.go
@@ -8,10 +8,11 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/kr/pretty"
+
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/netclient/config"
 	"github.com/gravitl/netmaker/netclient/functions"
-	"github.com/kr/pretty"
 )
 
 func main() {
@@ -32,11 +33,11 @@ func main() {
 	}
 	fmt.Println(response.StatusCode, response.Status)
 	if response.StatusCode != http.StatusOK {
-		bytes, err := io.ReadAll(response.Body)
+		resBytes, err := io.ReadAll(response.Body)
 		if err != nil {
 			fmt.Println(err)
 		}
-		pretty.Println(string(bytes))
+		_, _ = pretty.Println(string(resBytes))
 	}
 	defer response.Body.Close()
 	node := models.Node{}


### PR DESCRIPTION
 1) Avoid referencing conditions we know are false/true

 2) Avoid using name of imported package as variable

 3) Avoid broken (see list item 1) if else statement in `ipservice.go` by refactoring to switch statement

 4) When assigning a pointer value to a variable along with an error, check that error before referencing that pointer. **Thus avoiding de-referencing a nil and causing a panic**. (_This list item is by far the most important_)

 5) Standard gofmt package sorting + linting; This includes fixing comment starts for go doc

 6) Explicit non-handling of unhandled errors where appropriate (assigning errs to _ to reduce linter screaming)

 7) Export ErrExpired in `netcache` package so that we can properly reference it using `errors.Is` instead of using `strings.Contains` against an `error.Error()` value
 
 ---
 
 The project still doesn't quite pass `go vet ./...` unfortunately due to excessive usage of unkeyed fields when substantiating instances of defined types, but I already felt like this was a sizable commit to review without tacking that on.