### PR TITLE
Make FRONTEND_URL param required only for UI login

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -127,13 +126,7 @@ func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 //	  		oauth
 func HandleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if auth_provider == nil {
-		var referer = r.Header.Get("referer")
-		if referer != "" {
-			http.Redirect(w, r, referer+"login?oauth=callback-error", http.StatusTemporaryRedirect)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, oauthNotConfigured)
+		handleOauthNotConfigured(w)
 		return
 	}
 	var functions = getCurrentAuthFunctions()

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -72,10 +72,6 @@ func InitializeAuthProvider() string {
 		logger.Log(0, err.Error())
 		return ""
 	}
-	var currentFrontendURL = servercfg.GetFrontendURL()
-	if currentFrontendURL == "" {
-		return ""
-	}
 	var authInfo = servercfg.GetAuthProviderInfo()
 	var serverConn = servercfg.GetAPIHost()
 	if strings.Contains(serverConn, "localhost") || strings.Contains(serverConn, "127.0.0.1") {
@@ -131,6 +127,10 @@ func HandleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	var functions = getCurrentAuthFunctions()
 	if functions == nil {
+		return
+	}
+	if servercfg.GetFrontendURL() == "" {
+		handleOauthNotConfigured(w)
 		return
 	}
 	functions[handle_login].(func(http.ResponseWriter, *http.Request))(w, r)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -100,8 +100,7 @@ func InitializeAuthProvider() string {
 // Note: not included in API reference as part of the OAuth process itself.
 func HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	if auth_provider == nil {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, oauthNotConfigured)
+		handleOauthNotConfigured(w)
 		return
 	}
 	var functions = getCurrentAuthFunctions()

--- a/auth/azure-ad.go
+++ b/auth/azure-ad.go
@@ -37,16 +37,13 @@ func initAzureAD(redirectURL string, clientID string, clientSecret string) {
 
 func handleAzureLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
-	if auth_provider == nil && servercfg.GetFrontendURL() != "" {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
-		return
-	} else if auth_provider == nil {
-		fmt.Fprintf(w, "%s", []byte("no frontend URL was provided and an OAuth login was attempted\nplease reconfigure server to use OAuth or use basic credentials"))
+	if auth_provider == nil {
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 
@@ -60,7 +57,7 @@ func handleAzureCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getAzureUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from azure:", err.Error())
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.UserPrincipalName)

--- a/auth/azure-ad.go
+++ b/auth/azure-ad.go
@@ -38,12 +38,12 @@ func initAzureAD(redirectURL string, clientID string, clientSecret string) {
 func handleAzureLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
 	if auth_provider == nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
@@ -57,7 +57,7 @@ func handleAzureCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getAzureUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from azure:", err.Error())
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.UserPrincipalName)

--- a/auth/error.go
+++ b/auth/error.go
@@ -1,5 +1,7 @@
 package auth
 
+import "net/http"
+
 // == define error HTML here ==
 const oauthNotConfigured = `<!DOCTYPE html><html>
 <body>
@@ -7,3 +9,10 @@ const oauthNotConfigured = `<!DOCTYPE html><html>
 <p>Please visit the docs <a href="https://docs.netmaker.org/oauth.html" target="_blank" rel="noopener">here</a> to learn how to.</p>
 </body>
 </html>`
+
+// handleOauthNotConfigured - returns an appropriate html page when oauth is not configured on netmaker server but an oauth login was attempted
+func handleOauthNotConfigured(response http.ResponseWriter) {
+	response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	response.WriteHeader(http.StatusInternalServerError)
+	response.Write([]byte(oauthNotConfigured))
+}

--- a/auth/github.go
+++ b/auth/github.go
@@ -37,16 +37,13 @@ func initGithub(redirectURL string, clientID string, clientSecret string) {
 
 func handleGithubLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
-	if auth_provider == nil && servercfg.GetFrontendURL() != "" {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
-		return
-	} else if auth_provider == nil {
-		fmt.Fprintf(w, "%s", []byte("no frontend URL was provided and an OAuth login was attempted\nplease reconfigure server to use OAuth or use basic credentials"))
+	if auth_provider == nil {
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 
@@ -60,7 +57,7 @@ func handleGithubCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getGithubUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from github:", err.Error())
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.Login)

--- a/auth/github.go
+++ b/auth/github.go
@@ -38,12 +38,12 @@ func initGithub(redirectURL string, clientID string, clientSecret string) {
 func handleGithubLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
 	if auth_provider == nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
@@ -57,7 +57,7 @@ func handleGithubCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getGithubUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from github:", err.Error())
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.Login)

--- a/auth/google.go
+++ b/auth/google.go
@@ -39,12 +39,12 @@ func initGoogle(redirectURL string, clientID string, clientSecret string) {
 func handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
 	if auth_provider == nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
@@ -59,7 +59,7 @@ func handleGoogleCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getGoogleUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from google:", err.Error())
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.Email)

--- a/auth/nodecallback.go
+++ b/auth/nodecallback.go
@@ -40,7 +40,7 @@ func HandleNodeSSOCallback(w http.ResponseWriter, r *http.Request) {
 	var userClaims, err = functions[get_user_info].(func(string, string) (*OAuthUser, error))(state, code)
 	if err != nil {
 		logger.Log(0, "error when getting user info from callback:", err.Error())
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 

--- a/auth/nodecallback.go
+++ b/auth/nodecallback.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gravitl/netmaker/logic/pro/netcache"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/models/promodels"
-	"github.com/gravitl/netmaker/servercfg"
 )
 
 var (
@@ -41,7 +40,7 @@ func HandleNodeSSOCallback(w http.ResponseWriter, r *http.Request) {
 	var userClaims, err = functions[get_user_info].(func(string, string) (*OAuthUser, error))(state, code)
 	if err != nil {
 		logger.Log(0, "error when getting user info from callback:", err.Error())
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -51,12 +51,12 @@ func initOIDC(redirectURL string, clientID string, clientSecret string, issuer s
 func handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
 	if auth_provider == nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 	var url = auth_provider.AuthCodeURL(oauth_state_string)
@@ -70,7 +70,7 @@ func handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getOIDCUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from callback:", err.Error())
-		logic.HandleOauthNotConfigured(w)
+		handleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.Email)

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -50,16 +50,13 @@ func initOIDC(redirectURL string, clientID string, clientSecret string, issuer s
 
 func handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	var oauth_state_string = logic.RandomString(user_signin_length)
-	if auth_provider == nil && servercfg.GetFrontendURL() != "" {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
-		return
-	} else if auth_provider == nil {
-		fmt.Fprintf(w, "%s", []byte("no frontend URL was provided and an OAuth login was attempted\nplease reconfigure server to use OAuth or use basic credentials"))
+	if auth_provider == nil {
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 
 	if err := logic.SetState(oauth_state_string); err != nil {
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 	var url = auth_provider.AuthCodeURL(oauth_state_string)
@@ -73,7 +70,7 @@ func handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	var content, err = getOIDCUserInfo(rState, rCode)
 	if err != nil {
 		logger.Log(1, "error when getting user info from callback:", err.Error())
-		http.Redirect(w, r, servercfg.GetFrontendURL()+"/login?oauth=callback-error", http.StatusTemporaryRedirect)
+		logic.HandleOauthNotConfigured(w)
 		return
 	}
 	_, err = logic.GetUser(content.Email)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -20,7 +20,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "netmaker",
+	Use:   "nmctl",
 	Short: "CLI for interacting with Netmaker Server",
 	Long:  `CLI for interacting with Netmaker Server`,
 	// Uncomment the following line if your bare application

--- a/logic/errors.go
+++ b/logic/errors.go
@@ -56,10 +56,3 @@ func ReturnErrorResponse(response http.ResponseWriter, request *http.Request, er
 	response.WriteHeader(errorMessage.Code)
 	response.Write(jsonResponse)
 }
-
-// HandleOauthNotConfigured - returns an appropriate html page when oauth is not configured on netmaker server but an oauth login was attempted
-func HandleOauthNotConfigured(response http.ResponseWriter) {
-	response.Header().Set("Content-Type", "text/html; charset=utf-8")
-	response.WriteHeader(http.StatusInternalServerError)
-	response.Write([]byte("<html><body><h1>OAuth Login Failed, check if server is configured for OAuth.</h1></body></html>"))
-}

--- a/logic/errors.go
+++ b/logic/errors.go
@@ -56,3 +56,10 @@ func ReturnErrorResponse(response http.ResponseWriter, request *http.Request, er
 	response.WriteHeader(errorMessage.Code)
 	response.Write(jsonResponse)
 }
+
+// HandleOauthNotConfigured - returns an appropriate html page when oauth is not configured on netmaker server but an oauth login was attempted
+func HandleOauthNotConfigured(response http.ResponseWriter) {
+	response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	response.WriteHeader(http.StatusInternalServerError)
+	response.Write([]byte("<html><body><h1>OAuth Login Failed, check if server is configured for OAuth.</h1></body></html>"))
+}


### PR DESCRIPTION
The `FRONTEND_URL` is still required for successful login via redirect on oauth callbacks https://github.com/gravitl/netmaker/blob/master/auth/github.go#L89