### PR TITLE
Add host endpoints to cli and use new node struct

### DIFF
--- a/cli/cmd/acl/allow.go
+++ b/cli/cmd/acl/allow.go
@@ -2,8 +2,6 @@ package acl
 
 import (
 	"fmt"
-	"log"
-	"strings"
 
 	"github.com/gravitl/netmaker/cli/functions"
 	"github.com/gravitl/netmaker/logic/acls"
@@ -11,23 +9,13 @@ import (
 )
 
 var aclAllowCmd = &cobra.Command{
-	Use:   "allow [NETWORK NAME] [FROM_NODE_NAME] [TO_NODE_NAME]",
+	Use:   "allow [NETWORK NAME] [NODE_1_ID] [NODE_2_ID]",
 	Args:  cobra.ExactArgs(3),
 	Short: "Allow access from one node to another",
 	Long:  `Allow access from one node to another`,
 	Run: func(cmd *cobra.Command, args []string) {
-		nameIDMap := make(map[string]string)
-		for _, node := range *functions.GetNodes(args[0]) {
-			nameIDMap[strings.ToLower(node.Name)] = node.ID
-		}
-		fromNodeID, ok := nameIDMap[strings.ToLower(args[1])]
-		if !ok {
-			log.Fatalf("Node %s doesn't exist", args[1])
-		}
-		toNodeID, ok := nameIDMap[strings.ToLower(args[2])]
-		if !ok {
-			log.Fatalf("Node %s doesn't exist", args[2])
-		}
+		fromNodeID := args[1]
+		toNodeID := args[2]
 		payload := acls.ACLContainer(map[acls.AclID]acls.ACL{
 			acls.AclID(fromNodeID): map[acls.AclID]byte{
 				acls.AclID(toNodeID): acls.Allowed,

--- a/cli/cmd/acl/deny.go
+++ b/cli/cmd/acl/deny.go
@@ -2,8 +2,6 @@ package acl
 
 import (
 	"fmt"
-	"log"
-	"strings"
 
 	"github.com/gravitl/netmaker/cli/functions"
 	"github.com/gravitl/netmaker/logic/acls"
@@ -16,18 +14,8 @@ var aclDenyCmd = &cobra.Command{
 	Short: "Deny access from one node to another",
 	Long:  `Deny access from one node to another`,
 	Run: func(cmd *cobra.Command, args []string) {
-		nameIDMap := make(map[string]string)
-		for _, node := range *functions.GetNodes(args[0]) {
-			nameIDMap[strings.ToLower(node.Name)] = node.ID
-		}
-		fromNodeID, ok := nameIDMap[strings.ToLower(args[1])]
-		if !ok {
-			log.Fatalf("Node %s doesn't exist", args[1])
-		}
-		toNodeID, ok := nameIDMap[strings.ToLower(args[2])]
-		if !ok {
-			log.Fatalf("Node %s doesn't exist", args[2])
-		}
+		fromNodeID := args[1]
+		toNodeID := args[2]
 		payload := acls.ACLContainer(map[acls.AclID]acls.ACL{
 			acls.AclID(fromNodeID): map[acls.AclID]byte{
 				acls.AclID(toNodeID): acls.NotAllowed,

--- a/cli/cmd/acl/deny.go
+++ b/cli/cmd/acl/deny.go
@@ -9,7 +9,7 @@ import (
 )
 
 var aclDenyCmd = &cobra.Command{
-	Use:   "deny [NETWORK NAME] [FROM_NODE_NAME] [TO_NODE_NAME]",
+	Use:   "deny [NETWORK NAME] [NODE_1_ID] [NODE_2_ID]",
 	Args:  cobra.ExactArgs(3),
 	Short: "Deny access from one node to another",
 	Long:  `Deny access from one node to another`,

--- a/cli/cmd/acl/list.go
+++ b/cli/cmd/acl/list.go
@@ -16,16 +16,11 @@ var aclListCmd = &cobra.Command{
 	Long:  `List all ACLs associated with a network`,
 	Run: func(cmd *cobra.Command, args []string) {
 		aclSource := (map[acls.AclID]acls.ACL)(*functions.GetACL(args[0]))
-		nodes := functions.GetNodes(args[0])
-		idNameMap := make(map[string]string)
-		for _, node := range *nodes {
-			idNameMap[node.ID] = node.Name
-		}
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"From", "To", "Status"})
 		for id, acl := range aclSource {
 			for k, v := range (map[acls.AclID]byte)(acl) {
-				row := []string{idNameMap[string(id)], idNameMap[string(k)]}
+				row := []string{string(id), string(k)}
 				switch v {
 				case acls.NotAllowed:
 					row = append(row, "Not Allowed")

--- a/cli/cmd/acl/root.go
+++ b/cli/cmd/acl/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/acl/root.go
+++ b/cli/cmd/acl/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "acl",
 	Short: "Manage Access Control Lists (ACLs)",
 	Long:  `Manage Access Control Lists (ACLs)`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/context/root.go
+++ b/cli/cmd/context/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/context/root.go
+++ b/cli/cmd/context/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "context",
 	Short: "Manage various netmaker server configurations",
 	Long:  `Manage various netmaker server configurations`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/dns/root.go
+++ b/cli/cmd/dns/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/dns/root.go
+++ b/cli/cmd/dns/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "dns",
 	Short: "Manage DNS entries associated with a network",
 	Long:  `Manage DNS entries associated with a network`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/ext_client/root.go
+++ b/cli/cmd/ext_client/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/ext_client/root.go
+++ b/cli/cmd/ext_client/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "ext_client",
 	Short: "Manage External Clients",
 	Long:  `Manage External Clients`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/host/delete.go
+++ b/cli/cmd/host/delete.go
@@ -1,0 +1,20 @@
+package host
+
+import (
+	"github.com/gravitl/netmaker/cli/functions"
+	"github.com/spf13/cobra"
+)
+
+var hostDeleteCmd = &cobra.Command{
+	Use:   "delete HostID",
+	Args:  cobra.ExactArgs(1),
+	Short: "Delete a host",
+	Long:  `Delete a host`,
+	Run: func(cmd *cobra.Command, args []string) {
+		functions.PrettyPrint(functions.DeleteHost(args[0]))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostDeleteCmd)
+}

--- a/cli/cmd/host/list.go
+++ b/cli/cmd/host/list.go
@@ -1,0 +1,20 @@
+package host
+
+import (
+	"github.com/gravitl/netmaker/cli/functions"
+	"github.com/spf13/cobra"
+)
+
+var hostListCmd = &cobra.Command{
+	Use:   "list",
+	Args:  cobra.NoArgs,
+	Short: "List all hosts",
+	Long:  `List all hosts`,
+	Run: func(cmd *cobra.Command, args []string) {
+		functions.PrettyPrint(functions.GetHosts())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostListCmd)
+}

--- a/cli/cmd/host/root.go
+++ b/cli/cmd/host/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/host/root.go
+++ b/cli/cmd/host/root.go
@@ -1,0 +1,38 @@
+package host
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "host",
+	Short: "Manage hosts",
+	Long:  `Manage hosts`,
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// GetRoot returns the root subcommand
+func GetRoot() *cobra.Command {
+	return rootCmd
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cli/cmd/host/root.go
+++ b/cli/cmd/host/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "host",
 	Short: "Manage hosts",
 	Long:  `Manage hosts`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/host/update.go
+++ b/cli/cmd/host/update.go
@@ -23,23 +23,43 @@ var (
 )
 
 var hostUpdateCmd = &cobra.Command{
-	Use:   "update HostID /path/to/host_definition.json",
-	Args:  cobra.ExactArgs(2),
+	Use:   "update HostID",
+	Args:  cobra.ExactArgs(1),
 	Short: "Update a host",
 	Long:  `Update a host`,
 	Run: func(cmd *cobra.Command, args []string) {
 		apiHost := &models.ApiHost{}
-		content, err := os.ReadFile(args[1])
-		if err != nil {
-			log.Fatal("Error when opening file: ", err)
-		}
-		if err := json.Unmarshal(content, apiHost); err != nil {
-			log.Fatal(err)
+		if apiHostFilePath != "" {
+			content, err := os.ReadFile(apiHostFilePath)
+			if err != nil {
+				log.Fatal("Error when opening file: ", err)
+			}
+			if err := json.Unmarshal(content, apiHost); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			apiHost.EndpointIP = endpoint
+			apiHost.Name = name
+			apiHost.ListenPort = listenPort
+			apiHost.ProxyListenPort = proxyListenPort
+			apiHost.MTU = mtu
+			apiHost.ProxyEnabled = proxyEnabled
+			apiHost.IsStatic = isStatic
+			apiHost.IsDefault = isDefault
 		}
 		functions.PrettyPrint(functions.UpdateHost(args[0], apiHost))
 	},
 }
 
 func init() {
+	hostUpdateCmd.Flags().StringVar(&apiHostFilePath, "file", "", "Path to host_definition.json")
+	hostUpdateCmd.Flags().StringVar(&endpoint, "endpoint", "", "Endpoint of the Host")
+	hostUpdateCmd.Flags().StringVar(&name, "name", "", "Host name")
+	hostUpdateCmd.Flags().IntVar(&listenPort, "listen_port", 0, "Listen port of the host")
+	hostUpdateCmd.Flags().IntVar(&proxyListenPort, "proxy_listen_port", 0, "Proxy listen port of the host")
+	hostUpdateCmd.Flags().IntVar(&mtu, "mtu", 0, "Host MTU size")
+	hostUpdateCmd.Flags().BoolVar(&proxyEnabled, "proxy", false, "Enable proxy ?")
+	hostUpdateCmd.Flags().BoolVar(&isStatic, "static", false, "Make Host Static ?")
+	hostUpdateCmd.Flags().BoolVar(&isDefault, "default", false, "Make Host Default ?")
 	rootCmd.AddCommand(hostUpdateCmd)
 }

--- a/cli/cmd/host/update.go
+++ b/cli/cmd/host/update.go
@@ -10,6 +10,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	apiHostFilePath string
+	endpoint        string
+	name            string
+	listenPort      int
+	proxyListenPort int
+	mtu             int
+	proxyEnabled    bool
+	isStatic        bool
+	isDefault       bool
+)
+
 var hostUpdateCmd = &cobra.Command{
 	Use:   "update HostID /path/to/host_definition.json",
 	Args:  cobra.ExactArgs(2),

--- a/cli/cmd/host/update.go
+++ b/cli/cmd/host/update.go
@@ -1,0 +1,32 @@
+package host
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/gravitl/netmaker/cli/functions"
+	"github.com/spf13/cobra"
+)
+
+var hostUpdateCmd = &cobra.Command{
+	Use:   "update HostID /path/to/host_definition.json",
+	Args:  cobra.ExactArgs(2),
+	Short: "Update a host",
+	Long:  `Update a host`,
+	Run: func(cmd *cobra.Command, args []string) {
+		apiHost := &models.ApiHost{}
+		content, err := os.ReadFile(args[1])
+		if err != nil {
+			log.Fatal("Error when opening file: ", err)
+		}
+		if err := json.Unmarshal(content, apiHost); err != nil {
+			log.Fatal(err)
+		}
+		functions.PrettyPrint(functions.UpdateHost(args[0], apiHost))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostUpdateCmd)
+}

--- a/cli/cmd/host/update.go
+++ b/cli/cmd/host/update.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/gravitl/netmaker/cli/functions"
+	"github.com/gravitl/netmaker/models"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/host/update_networks.go
+++ b/cli/cmd/host/update_networks.go
@@ -1,0 +1,22 @@
+package host
+
+import (
+	"strings"
+
+	"github.com/gravitl/netmaker/cli/functions"
+	"github.com/spf13/cobra"
+)
+
+var hostUpdateNetworksCmd = &cobra.Command{
+	Use:   "update_network HostID Networks(comma separated list)",
+	Args:  cobra.ExactArgs(2),
+	Short: "Update a host's networks",
+	Long:  `Update a host's networks`,
+	Run: func(cmd *cobra.Command, args []string) {
+		functions.PrettyPrint(functions.UpdateHostNetworks(args[0], strings.Split(args[1], ",")))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostUpdateNetworksCmd)
+}

--- a/cli/cmd/keys/root.go
+++ b/cli/cmd/keys/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/keys/root.go
+++ b/cli/cmd/keys/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "keys",
 	Short: "Manage access keys associated with a network",
 	Long:  `Manage access keys associated with a network`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/metrics/root.go
+++ b/cli/cmd/metrics/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/metrics/root.go
+++ b/cli/cmd/metrics/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "metrics",
 	Short: "Fetch metrics of nodes/networks",
 	Long:  `Fetch metrics of nodes/networks`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/network/root.go
+++ b/cli/cmd/network/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/network/root.go
+++ b/cli/cmd/network/root.go
@@ -11,9 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "network",
 	Short: "Manage Netmaker Networks",
 	Long:  `Manage Netmaker Networks`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/network_user/root.go
+++ b/cli/cmd/network_user/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/network_user/root.go
+++ b/cli/cmd/network_user/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "network_user",
 	Short: "Manage Network Users",
 	Long:  `Manage Network Users`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/node/flags.go
+++ b/cli/cmd/node/flags.go
@@ -6,23 +6,17 @@ var (
 	failover               bool
 	networkName            string
 	nodeDefinitionFilePath string
-	endpoint               string
-	listenPort             int
 	address                string
 	address6               string
 	localAddress           string
 	name                   string
 	postUp                 string
 	postDown               string
-	allowedIPs             string
 	keepAlive              int
 	relayAddrs             string
 	egressGatewayRanges    string
-	localRange             string
-	mtu                    int
 	expirationDateTime     int
 	defaultACL             bool
 	dnsOn                  bool
 	disconnect             bool
-	networkHub             bool
 )

--- a/cli/cmd/node/list.go
+++ b/cli/cmd/node/list.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/gravitl/netmaker/cli/functions"
 	"github.com/gravitl/netmaker/models"
@@ -23,19 +24,20 @@ var nodeListCmd = &cobra.Command{
 			data = *functions.GetNodes()
 		}
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Name", "Addresses", "Version", "Network", "Egress", "Ingress", "Relay", "ID"})
+		table.SetHeader([]string{"ID", "Addresses", "Network", "Egress", "Ingress", "Relay"})
 		for _, d := range data {
 			addresses := ""
-			if d.Address != "" {
-				addresses += d.Address
+			if d.Address.String() != "" {
+				addresses += d.Address.String()
 			}
-			if d.Address6 != "" {
-				if d.Address != "" {
+			if d.Address6.String() != "" {
+				if d.Address.String() != "" {
 					addresses += ", "
 				}
-				addresses += d.Address6
+				addresses += d.Address6.String()
 			}
-			table.Append([]string{d.Name, addresses, d.Version, d.Network, d.IsEgressGateway, d.IsIngressGateway, d.IsRelay, d.ID})
+			table.Append([]string{d.ID.String(), addresses, d.Network,
+				strconv.FormatBool(d.IsEgressGateway), strconv.FormatBool(d.IsIngressGateway), strconv.FormatBool(d.IsRelay)})
 		}
 		table.Render()
 	},

--- a/cli/cmd/node/root.go
+++ b/cli/cmd/node/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/node/root.go
+++ b/cli/cmd/node/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "node",
 	Short: "Manage nodes associated with a network",
 	Long:  `Manage nodes associated with a network`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/node/update.go
+++ b/cli/cmd/node/update.go
@@ -3,8 +3,10 @@ package node
 import (
 	"encoding/json"
 	"log"
+	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gravitl/netmaker/cli/functions"
 	"github.com/gravitl/netmaker/models"
@@ -31,45 +33,43 @@ var nodeUpdateCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 		} else {
-			if endpoint != "" {
-				node.Endpoint = endpoint
-				node.IsStatic = "no"
+			if address != "" {
+				if _, addr, err := net.ParseCIDR(address); err != nil {
+					log.Fatal(err)
+				} else {
+					node.Address = *addr
+				}
 			}
-			node.ListenPort = int32(listenPort)
-			node.Address = address
-			node.Address6 = address6
-			node.LocalAddress = localAddress
-			node.Name = name
+			if address6 != "" {
+				if _, addr6, err := net.ParseCIDR(address6); err != nil {
+					log.Fatal(err)
+				} else {
+					node.Address6 = *addr6
+				}
+			}
+			if localAddress != "" {
+				if _, localAddr, err := net.ParseCIDR(localAddress); err != nil {
+					log.Fatal(err)
+				} else {
+					node.LocalAddress = *localAddr
+					node.IsLocal = true
+				}
+			}
 			node.PostUp = postUp
 			node.PostDown = postDown
-			if allowedIPs != "" {
-				node.AllowedIPs = strings.Split(allowedIPs, ",")
-			}
-			node.PersistentKeepalive = int32(keepAlive)
+			node.PersistentKeepalive = time.Duration(time.Second * time.Duration(keepAlive))
 			if relayAddrs != "" {
 				node.RelayAddrs = strings.Split(relayAddrs, ",")
 			}
 			if egressGatewayRanges != "" {
 				node.EgressGatewayRanges = strings.Split(egressGatewayRanges, ",")
 			}
-			if localRange != "" {
-				node.LocalRange = localRange
-				node.IsLocal = "yes"
-			}
-			node.MTU = int32(mtu)
-			node.ExpirationDateTime = int64(expirationDateTime)
+			node.ExpirationDateTime = time.Unix(int64(expirationDateTime), 0)
 			if defaultACL {
 				node.DefaultACL = "yes"
 			}
-			if dnsOn {
-				node.DNSOn = "yes"
-			}
-			if disconnect {
-				node.Connected = "no"
-			}
-			if networkHub {
-				node.IsHub = "yes"
-			}
+			node.DNSOn = dnsOn
+			node.Connected = !disconnect
 		}
 		functions.PrettyPrint(functions.UpdateNode(networkName, nodeID, node))
 	},
@@ -77,24 +77,18 @@ var nodeUpdateCmd = &cobra.Command{
 
 func init() {
 	nodeUpdateCmd.Flags().StringVar(&nodeDefinitionFilePath, "file", "", "Filepath of updated node definition in JSON")
-	nodeUpdateCmd.Flags().StringVar(&endpoint, "endpoint", "", "Public endpoint of the node")
-	nodeUpdateCmd.Flags().IntVar(&listenPort, "listen_port", 0, "Default wireguard port for the node")
 	nodeUpdateCmd.Flags().StringVar(&address, "ipv4_addr", "", "IPv4 address of the node")
 	nodeUpdateCmd.Flags().StringVar(&address6, "ipv6_addr", "", "IPv6 address of the node")
 	nodeUpdateCmd.Flags().StringVar(&localAddress, "local_addr", "", "Locally reachable address of the node")
 	nodeUpdateCmd.Flags().StringVar(&name, "name", "", "Node name")
 	nodeUpdateCmd.Flags().StringVar(&postUp, "post_up", "", "Commands to run after node is up `;` separated")
 	nodeUpdateCmd.Flags().StringVar(&postDown, "post_down", "", "Commands to run after node is down `;` separated")
-	nodeUpdateCmd.Flags().StringVar(&allowedIPs, "allowed_addrs", "", "Additional private addresses given to the node (comma separated)")
 	nodeUpdateCmd.Flags().IntVar(&keepAlive, "keep_alive", 0, "Interval in which packets are sent to keep connections open with peers")
 	nodeUpdateCmd.Flags().StringVar(&relayAddrs, "relay_addrs", "", "Addresses for relaying connections if node acts as a relay")
 	nodeUpdateCmd.Flags().StringVar(&egressGatewayRanges, "egress_addrs", "", "Addresses for egressing traffic if node acts as an egress")
-	nodeUpdateCmd.Flags().StringVar(&localRange, "local_range", "", "Local range in which the node will look for private addresses to use as an endpoint if `LocalNetwork` is enabled")
-	nodeUpdateCmd.Flags().IntVar(&mtu, "mtu", 0, "MTU size")
 	nodeUpdateCmd.Flags().IntVar(&expirationDateTime, "expiry", 0, "UNIX timestamp after which node will lose access to the network")
 	nodeUpdateCmd.Flags().BoolVar(&defaultACL, "acl", false, "Enable default ACL ?")
 	nodeUpdateCmd.Flags().BoolVar(&dnsOn, "dns", false, "Setup DNS entries for peers locally ?")
 	nodeUpdateCmd.Flags().BoolVar(&disconnect, "disconnect", false, "Disconnect from the network ?")
-	nodeUpdateCmd.Flags().BoolVar(&networkHub, "hub", false, "On a point to site network, this node is the only one which all peers connect to ?")
 	rootCmd.AddCommand(nodeUpdateCmd)
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gravitl/netmaker/cli/cmd/context"
 	"github.com/gravitl/netmaker/cli/cmd/dns"
 	"github.com/gravitl/netmaker/cli/cmd/ext_client"
+	"github.com/gravitl/netmaker/cli/cmd/host"
 	"github.com/gravitl/netmaker/cli/cmd/keys"
 	"github.com/gravitl/netmaker/cli/cmd/metrics"
 	"github.com/gravitl/netmaker/cli/cmd/network"
@@ -66,4 +67,5 @@ func init() {
 	rootCmd.AddCommand(usergroup.GetRoot())
 	rootCmd.AddCommand(metrics.GetRoot())
 	rootCmd.AddCommand(network_user.GetRoot())
+	rootCmd.AddCommand(host.GetRoot())
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -41,17 +41,7 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.tctl.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-	// IMP: Bind subcommands here
+	// Bind subcommands here
 	rootCmd.AddCommand(network.GetRoot())
 	rootCmd.AddCommand(context.GetRoot())
 	rootCmd.AddCommand(keys.GetRoot())

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -24,9 +24,6 @@ var rootCmd = &cobra.Command{
 	Use:   "nmctl",
 	Short: "CLI for interacting with Netmaker Server",
 	Long:  `CLI for interacting with Netmaker Server`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root of all subcommands

--- a/cli/cmd/server/root.go
+++ b/cli/cmd/server/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/server/root.go
+++ b/cli/cmd/server/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Get netmaker server information",
 	Long:  `Get netmaker server information`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/user/root.go
+++ b/cli/cmd/user/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/user/root.go
+++ b/cli/cmd/user/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Manage users and permissions",
 	Long:  `Manage users and permissions`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/cmd/usergroup/root.go
+++ b/cli/cmd/usergroup/root.go
@@ -26,12 +26,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}

--- a/cli/cmd/usergroup/root.go
+++ b/cli/cmd/usergroup/root.go
@@ -11,7 +11,6 @@ var rootCmd = &cobra.Command{
 	Use:   "usergroup",
 	Short: "Manage User Groups",
 	Long:  `Manage User Groups`,
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // GetRoot returns the root subcommand

--- a/cli/functions/host.go
+++ b/cli/functions/host.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"net/http"
+
+	"github.com/gravitl/netmaker/models"
+)
+
+type hostNetworksUpdatePayload struct {
+	Networks []string `json:"networks"`
+}
+
+// GetHosts - fetch all host entries
+func GetHosts() *[]models.ApiHost {
+	return request[[]models.ApiHost](http.MethodGet, "/api/hosts", nil)
+}
+
+// DeleteHost - delete a host
+func DeleteHost(hostID string) *models.ApiHost {
+	return request[models.ApiHost](http.MethodDelete, "/api/hosts/"+hostID, nil)
+}
+
+// UpdateHost - update a host
+func UpdateHost(hostID string, body *models.ApiHost) *models.ApiHost {
+	return request[models.ApiHost](http.MethodPut, "/api/hosts/"+hostID, body)
+}
+
+// UpdateHostNetworks - update a host's networks
+func UpdateHostNetworks(hostID string, networks []string) *hostNetworksUpdatePayload {
+	return request[hostNetworksUpdatePayload](http.MethodPut, "/api/hosts/"+hostID+"/networks", &hostNetworksUpdatePayload{
+		Networks: networks,
+	})
+}


### PR DESCRIPTION
Testing can be done when `netclient_refactor_latest` is merged into develop because it contains `models.ApiHost`

Merge this after `netclient_refactor_latest` is merged