### PR TITLE
Add space after double slash in comment

### DIFF
--- a/netclient/gui/gui.go
+++ b/netclient/gui/gui.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gravitl/netmaker/netclient/ncutils"
 )
 
-//go:embed nm-logo-sm.png
+// go:embed nm-logo-sm.png
 var logoContent embed.FS
 
 // Run - run's the netclient GUI


### PR DESCRIPTION
The build breaks here if the comment is not properly formatted