### PR TITLE
ignored nodes with PendingDelete set

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -348,7 +348,7 @@ func GetPeerUpdateForHost(host *models.Host) (models.HostPeerUpdate, error) {
 		if err != nil {
 			continue
 		}
-		if !node.Connected || node.Action == models.NODE_DELETE {
+		if !node.Connected || node.Action == models.NODE_DELETE || node.PendingDelete {
 			continue
 		}
 		hostPeerUpdate.Network[node.Network] = models.NetworkInfo{


### PR DESCRIPTION
To test:
- Join at least 2 nodes
- Turn off daemon on one of the hosts
- Delete that host's node via API (UI or NMCTL).
- The other should no longer have that node in it's peers
