### PR TITLE
ensured host, if found, keeps password

### DIFF
--- a/controllers/node.go
+++ b/controllers/node.go
@@ -524,7 +524,7 @@ func createNode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !logic.IsVersionComptatible(data.Host.Version) {
-		err := errors.New("incomatible netclient version")
+		err := errors.New("incompatible netclient version")
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))
 		return
 	}
@@ -600,6 +600,7 @@ func createNode(w http.ResponseWriter, r *http.Request) {
 				logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
 				return
 			}
+			data.Host = *host
 		} else {
 			logger.Log(0, "error creating host", err.Error())
 			logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))

--- a/controllers/node.go
+++ b/controllers/node.go
@@ -653,6 +653,8 @@ func createNode(w http.ResponseWriter, r *http.Request) {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
 		return
 	}
+	data.Host.HostPass = "" // client should not change password after join
+	// concealing hash
 	response := models.NodeJoinResponse{
 		Node:         data.Node,
 		ServerConfig: server,


### PR DESCRIPTION
To test:

- [x] Join 2 or more networks with the same netclient/host
- [x] Ensure password doesn't change
- [x] Ensure `netclient list -l` is able to authenticate (or another API call [pull?])