### PR TITLE
GRA-1903: skip ext client from peer list  when disabled

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -741,7 +741,7 @@ func getExtPeers(node *models.Node) ([]wgtypes.PeerConfig, []models.IDandAddr, e
 		}
 
 		if host.PublicKey.String() == extPeer.PublicKey ||
-			extPeer.IngressGatewayID != node.ID.String() {
+			extPeer.IngressGatewayID != node.ID.String() || !extPeer.Enabled {
 			continue
 		}
 
@@ -806,7 +806,7 @@ func getExtPeersForProxy(node *models.Node, proxyPeerConf map[string]models.Peer
 		}
 
 		if host.PublicKey.String() == extPeer.PublicKey ||
-			extPeer.IngressGatewayID != node.ID.String() {
+			extPeer.IngressGatewayID != node.ID.String() || !extPeer.Enabled {
 			continue
 		}
 


### PR DESCRIPTION
Testing steps:

- [x] when extclient is disabled from the UI it shouldn't appear on your interface as a peer