### PR TITLE
Gra 1155: send peer update after adding host to network

### DIFF
--- a/controllers/hosts.go
+++ b/controllers/hosts.go
@@ -224,6 +224,11 @@ func addHostToNetwork(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		logger.Log(0, r.Header.Get("user"), "failed to update host to join network:", hostid, network, err.Error())
 	}
+	go func() { // notify of peer change
+		if err := mq.PublishPeerUpdate(); err != nil {
+			logger.Log(1, "error publishing peer update ", err.Error())
+		}
+	}()
 
 	logger.Log(2, r.Header.Get("user"), fmt.Sprintf("added host %s to network %s", currHost.Name, network))
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- [x] check whether network peers are added to a host when it's joined to a network from UI