### PR TITLE
adapt createNetwork + default host addition

### DIFF
--- a/controllers/network.go
+++ b/controllers/network.go
@@ -403,11 +403,6 @@ func createNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = logic.AddDefaultHostsToNetwork(network.NetID, servercfg.GetServer()); err != nil {
-		logger.Log(0, fmt.Sprintf("failed to add default hosts to network [%v]: %v",
-			network.NetID, err.Error()))
-	}
-
 	defaultHosts := logic.GetDefaultHosts()
 	for i := range defaultHosts {
 		currHost := &defaultHosts[i]

--- a/logic/hosts.go
+++ b/logic/hosts.go
@@ -216,6 +216,7 @@ func UpdateHostNetwork(h *models.Host, network string, add bool) (*models.Node, 
 		newNode := models.Node{}
 		newNode.Server = servercfg.GetServer()
 		newNode.Network = network
+		newNode.HostID = h.ID
 		if err := AssociateNodeToHost(&newNode, h); err != nil {
 			return nil, err
 		}
@@ -306,21 +307,6 @@ func GetDefaultHosts() []models.Host {
 		}
 	}
 	return defaultHostList[:]
-}
-
-// AddDefaultHostsToNetwork - adds a node to network for every default host on Netmaker server
-func AddDefaultHostsToNetwork(network, server string) error {
-	// add default hosts to network
-	defaultHosts := GetDefaultHosts()
-	for i := range defaultHosts {
-		newNode := models.Node{}
-		newNode.Network = network
-		newNode.Server = server
-		if err := AssociateNodeToHost(&newNode, &defaultHosts[i]); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // GetHostNetworks - fetches all the networks


### PR DESCRIPTION
There was an issue with adding nodes to hosts without host IDs being set on network create.
Fixed, so that it is more similar to the actual endpoint.
To test:

- [ ] Ensure that when a network is created, a node with a default Host's HOST ID is created on that network for each default host  on the server