### PR TITLE
Fix issue with deleting nodes from default hosts

### DIFF
--- a/controllers/hosts.go
+++ b/controllers/hosts.go
@@ -268,12 +268,15 @@ func deleteHostFromNetwork(w http.ResponseWriter, r *http.Request) {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
 		return
 	}
+	node.Action = models.NODE_DELETE
+	node.PendingDelete = true
 	logger.Log(1, "deleting  node", node.ID.String(), "from host", currHost.Name)
 	if err := logic.DeleteNode(node, false); err != nil {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(fmt.Errorf("failed to delete node"), "internal"))
 		return
 	}
 	// notify node change
+
 	runUpdates(node, false)
 	go func() { // notify of peer change
 		if err := mq.PublishPeerUpdate(); err != nil {

--- a/mq/publishers.go
+++ b/mq/publishers.go
@@ -83,7 +83,7 @@ func NodeUpdate(node *models.Node) error {
 		logger.Log(2, "error marshalling node update ", err.Error())
 		return err
 	}
-	if err = publish(host, fmt.Sprintf("update/%s/%s", node.Network, node.ID), data); err != nil {
+	if err = publish(host, fmt.Sprintf("node/update/%s/%s", node.Network, node.ID), data); err != nil {
 		logger.Log(2, "error publishing node update to peer ", node.ID.String(), err.Error())
 		return err
 	}


### PR DESCRIPTION
To test: Use client in PR https://github.com/gravitl/netclient/pull/218


- [x] Ensure a default Host gets via Nodes added to all networks created after initial join
- [x] Ensure user can delete those nodes
- [x] Ensure user can delete the host after the nodes