### PR TITLE
GRA-1324 - node force deletion

### DIFF
--- a/logic/hosts.go
+++ b/logic/hosts.go
@@ -395,6 +395,21 @@ func HostExists(h *models.Host) bool {
 	return (err != nil && !database.IsEmptyRecord(err)) || (err == nil)
 }
 
+// GetHostByNodeID - returns a host if found to have a node's ID, else nil
+func GetHostByNodeID(id string) *models.Host {
+	hosts, err := GetAllHosts()
+	if err != nil {
+		return nil
+	}
+	for i := range hosts {
+		h := hosts[i]
+		if StringSliceContains(h.Nodes, id) {
+			return &h
+		}
+	}
+	return nil
+}
+
 func updatePort(p *int) {
 	*p++
 	if *p > maxPort {


### PR DESCRIPTION
## Describe your changes
- If a node has been requested for deletion twice, it will be forcible removed now
- If a valid host performs a checkin for a node that doesn't exist, it will be messaged to remove it
## Provide Issue ticket number if applicable/not in title
title.
## Provide testing steps

- [x] register a host to two networks
- [x] Ensure you can remove one node from the host normally while connected to broker
- [x] kill the daemon process and delete the remaining node once, ensure it appears greyed out in UI or pendingdelete is true
- [x] delete the node a second time and ensure it is gone, restart host daemon and ensure it clears out the nodes.yml file for that node after a check-in

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
