### PR TITLE
GRA-1335 allowed public key input for ext clients

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gravitl/netmaker/models/promodels"
 	"github.com/gravitl/netmaker/mq"
 	"github.com/skip2/go-qrcode"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func extClientHandlers(r *mux.Router) {
@@ -317,16 +318,22 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var extclient models.ExtClient
-	var CustomExtClient models.CustomExtClient
+	var customExtClient models.CustomExtClient
 
-	err := json.NewDecoder(r.Body).Decode(&CustomExtClient)
-
+	err := json.NewDecoder(r.Body).Decode(&customExtClient)
 	if err == nil {
-		if CustomExtClient.ClientID != "" && !validName(CustomExtClient.ClientID) {
+		if customExtClient.ClientID != "" && !validName(customExtClient.ClientID) {
 			logic.ReturnErrorResponse(w, r, logic.FormatError(errInvalidExtClientID, "badrequest"))
 			return
 		}
-		extclient.ClientID = CustomExtClient.ClientID
+		extclient.ClientID = customExtClient.ClientID
+		if len(customExtClient.PublicKey) > 0 {
+			if _, err := wgtypes.ParseKey(customExtClient.PublicKey); err != nil {
+				logic.ReturnErrorResponse(w, r, logic.FormatError(errInvalidExtClientPubKey, "badrequest"))
+				return
+			}
+			extclient.PublicKey = customExtClient.PublicKey
+		}
 	}
 
 	extclient.Network = networkName
@@ -350,16 +357,13 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 		listenPort = host.ProxyListenPort
 	}
 	extclient.IngressGatewayEndpoint = host.EndpointIP.String() + ":" + strconv.FormatInt(int64(listenPort), 10)
-
 	extclient.Enabled = true
 	parentNetwork, err := logic.GetNetwork(networkName)
 	if err == nil { // check if parent network default ACL is enabled (yes) or not (no)
 		extclient.Enabled = parentNetwork.DefaultACL == "yes"
 	}
-	// check pro settings
 
-	err = logic.CreateExtClient(&extclient)
-	if err != nil {
+	if err = logic.CreateExtClient(&extclient); err != nil {
 		logger.Log(0, r.Header.Get("user"),
 			fmt.Sprintf("failed to create new ext client on network [%s]: %v", networkName, err))
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
@@ -389,8 +393,7 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 	logger.Log(0, r.Header.Get("user"), "created new ext client on network", networkName)
 	w.WriteHeader(http.StatusOK)
 	go func() {
-		err = mq.PublishPeerUpdate()
-		if err != nil {
+		if err := mq.PublishPeerUpdate(); err != nil {
 			logger.Log(1, "error setting ext peers on "+nodeid+": "+err.Error())
 		}
 		if err := mq.PublishExtCLientDNS(&extclient); err != nil {

--- a/controllers/regex.go
+++ b/controllers/regex.go
@@ -5,7 +5,10 @@ import (
 	"regexp"
 )
 
-var errInvalidExtClientID = errors.New("ext client ID must be alphanumderic and/or dashes")
+var (
+	errInvalidExtClientPubKey = errors.New("incorrect ext client public key")
+	errInvalidExtClientID     = errors.New("ext client ID must be alphanumderic and/or dashes")
+)
 
 // allow only dashes and alphaneumeric for ext client and node names
 func validName(name string) bool {

--- a/logic/extpeers.go
+++ b/logic/extpeers.go
@@ -117,14 +117,15 @@ func GetExtClient(clientid string, network string) (models.ExtClient, error) {
 // CreateExtClient - creates an extclient
 func CreateExtClient(extclient *models.ExtClient) error {
 
-	if extclient.PrivateKey == "" {
+	if len(extclient.PublicKey) == 0 {
 		privateKey, err := wgtypes.GeneratePrivateKey()
 		if err != nil {
 			return err
 		}
-
 		extclient.PrivateKey = privateKey.String()
 		extclient.PublicKey = privateKey.PublicKey().String()
+	} else {
+		extclient.PrivateKey = "[ENTER PRIVATE KEY]"
 	}
 
 	parentNetwork, err := GetNetwork(extclient.Network)
@@ -156,7 +157,6 @@ func CreateExtClient(extclient *models.ExtClient) error {
 	}
 
 	extclient.LastModified = time.Now().Unix()
-
 	key, err := GetRecordKey(extclient.ClientID, extclient.Network)
 	if err != nil {
 		return err

--- a/models/structs.go
+++ b/models/structs.go
@@ -8,12 +8,17 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-const PLACEHOLDER_KEY_TEXT = "ACCESS_KEY"
-const PLACEHOLDER_TOKEN_TEXT = "ACCESS_TOKEN"
+const (
+	// PLACEHOLDER_KEY_TEXT - access key placeholder text if option turned off
+	PLACEHOLDER_KEY_TEXT = "ACCESS_KEY"
+	// PLACEHOLDER_TOKEN_TEXT - access key token placeholder text if option turned off
+	PLACEHOLDER_TOKEN_TEXT = "ACCESS_TOKEN"
+)
 
 // CustomExtClient - struct for CustomExtClient params
 type CustomExtClient struct {
-	ClientID string `json:"clientid"`
+	ClientID  string `json:"clientid"`
+	PublicKey string `json:"publickey,omitempty"`
 }
 
 // AuthParams - struct for auth params


### PR DESCRIPTION
## Describe your changes
- Added ability to provide a public key for ext client creation if desired
## Provide Issue ticket number if applicable/not in title
title.

## Provide testing steps
- [x] Create an ext client with custom name + public key (use wg-tools or other to generate priv/pub key pairs to test)
  - `curl -X POST -H "Authorization: Bearer <admin JWT/masterkey>" -d '{"clientid":"myclientid","publickey":"<wg pub key>"}' https://{myserverdomain}/api/extclients/{netword-id}/{ingress-node-id}
- [x] Download client config, ensure you see [ENTER PRIVATE KEY] in config and replace with your private key
- [x] Ensure connection is established as normal
- [x] Attempt to create ext client with invalid public key and ensure failure

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
