### PR TITLE
GRA-1345: added ability to remove legacy nodes

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -27,6 +27,7 @@ var HttpHandlers = []interface{}{
 	loggerHandlers,
 	hostHandlers,
 	enrollmentKeyHandlers,
+	legacyHandlers,
 }
 
 // HandleRESTRequests - handles the rest requests

--- a/controllers/legacy.go
+++ b/controllers/legacy.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/gravitl/netmaker/logger"
+	"github.com/gravitl/netmaker/logic"
+)
+
+func legacyHandlers(r *mux.Router) {
+	r.HandleFunc("/api/v1/legacy/nodes", logic.SecurityCheck(true, http.HandlerFunc(wipeLegacyNodes))).Methods(http.MethodDelete)
+}
+
+// swagger:route DELETE /api/v1/legacy/nodes nodes wipeLegacyNodes
+//
+// Delete all legacy nodes from DB.
+//
+//			Schemes: https
+//
+//			Security:
+//	  		oauth
+//
+//			Responses:
+//				200: wipeLegacyNodesResponse
+func wipeLegacyNodes(w http.ResponseWriter, r *http.Request) {
+	// Set header
+	w.Header().Set("Content-Type", "application/json")
+	if err := logic.RemoveAllLegacyNodes(); err != nil {
+		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))
+		logger.Log(0, "error occurred when removing legacy nodes", err.Error())
+	}
+	logger.Log(0, r.Header.Get("user"), "wiped legacy nodes")
+	logic.ReturnSuccessResponse(w, r, "wiped all legacy nodes")
+}

--- a/controllers/node.go
+++ b/controllers/node.go
@@ -975,8 +975,13 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 	fromNode := r.Header.Get("requestfrom") == "node"
 	node, err := logic.GetNodeByID(nodeid)
 	if err != nil {
-		logger.Log(0, "error retrieving node to delete", err.Error())
-		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))
+		if logic.CheckAndRemoveLegacyNode(nodeid) {
+			logger.Log(0, "removed legacy node", nodeid)
+			logic.ReturnSuccessResponse(w, r, nodeid+" deleted.")
+		} else {
+			logger.Log(0, "error retrieving node to delete", err.Error())
+			logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))
+		}
 		return
 	}
 	if r.Header.Get("ismaster") != "yes" {

--- a/logic/legacy.go
+++ b/logic/legacy.go
@@ -1,0 +1,46 @@
+package logic
+
+import (
+	"encoding/json"
+
+	"github.com/gravitl/netmaker/database"
+	"github.com/gravitl/netmaker/logger"
+	"github.com/gravitl/netmaker/models"
+)
+
+// IsLegacyNode - checks if a node is legacy or not
+func IsLegacyNode(nodeID string) bool {
+	record, err := database.FetchRecord(database.NODES_TABLE_NAME, nodeID)
+	if err != nil {
+		return false
+	}
+	var currentNode models.Node
+	var legacyNode models.LegacyNode
+	currentNodeErr := json.Unmarshal([]byte(record), &currentNode)
+	legacyNodeErr := json.Unmarshal([]byte(record), &legacyNode)
+	return currentNodeErr != nil && legacyNodeErr == nil
+}
+
+// CheckAndRemoveLegacyNode - checks for legacy node and removes
+func CheckAndRemoveLegacyNode(nodeID string) bool {
+	if IsLegacyNode(nodeID) {
+		if err := database.DeleteRecord(database.NODES_TABLE_NAME, nodeID); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveAllLegacyNodes - fetches all legacy nodes from DB and removes
+func RemoveAllLegacyNodes() error {
+	records, err := database.FetchRecords(database.NODES_TABLE_NAME)
+	if err != nil {
+		return err
+	}
+	for k := range records {
+		if CheckAndRemoveLegacyNode(k) {
+			logger.Log(0, "removed legacy node", k)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Describe your changes
- Added re-usable util check for legacy nodes
- Added removal func for legacy nodes
## Provide Issue ticket number if applicable/not in title
title.
## Provide testing steps
- [x] Use an upgraded server with legacy nodes on it ensure you have at least 2
- [x] Remove 1 legacy node From legacy node: call `uninstall` or `leave`, or get legacy Node ID and call `curl -X DELETE -H "Authorization Bearer <masterkey/admin jwt>" https://<yourdomain>/api/nodes/{network}/{nodeid}` 
- [x] then call  `curl -X DELETE -H "Authorization Bearer <masterkey/admin jwt>" https://<yourdomain>/api/v1/legacy/nodes` and ensure other legacy node is removed

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
