### PR TITLE
GRA-1363 - adapted to get ports on response

### DIFF
--- a/controllers/enrollmentkeys.go
+++ b/controllers/enrollmentkeys.go
@@ -200,9 +200,13 @@ func handleHostRegister(w http.ResponseWriter, r *http.Request) {
 	// ready the response
 	server := servercfg.GetServerInfo()
 	server.TrafficKey = key
+	response := models.RegisterResponse{
+		ServerConf:    server,
+		RequestedHost: newHost,
+	}
 	logger.Log(0, newHost.Name, newHost.ID.String(), "registered with Netmaker")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(&server)
+	json.NewEncoder(w).Encode(&response)
 	// notify host of changes, peer and node updates
 	go checkNetRegAndHostUpdate(enrollmentKey.Networks, &newHost)
 }

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -198,7 +198,7 @@ func GetPeerUpdateForHost(ctx context.Context, network string, host *models.Host
 				peerConfig.ReplaceAllowedIPs = true
 				uselocal := false
 				if host.EndpointIP.String() == peerHost.EndpointIP.String() {
-					//peer is on same network
+					// peer is on same network
 					// set to localaddress
 					uselocal = true
 					if node.LocalAddress.IP == nil {

--- a/models/enrollment_key.go
+++ b/models/enrollment_key.go
@@ -34,6 +34,12 @@ type APIEnrollmentKey struct {
 	Tags          []string `json:"tags"`
 }
 
+// RegisterResponse - the response to a successful enrollment register
+type RegisterResponse struct {
+	ServerConf    ServerConfig `json:"server_config"`
+	RequestedHost Host         `json:"requested_host"`
+}
+
 // EnrollmentKey.IsValid - checks if the key is still valid to use
 func (k *EnrollmentKey) IsValid() bool {
 	if k == nil {


### PR DESCRIPTION
## Describe your changes
- simplified port check so no memory de-referencing
- adjust response on register to send back host
## Provide Issue ticket number if applicable/not in title
title.
## Provide testing steps

- [x] ensure ports are correct after joining/registering with 2 hosts on same NAT

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [x] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
