### PR TITLE
Story/gra 1431

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -647,7 +647,7 @@ setup_mesh() {
 
 	echo "Creating netmaker enrollment key"
 
-	tokenJson=$(nmctl enrollment_key create --uses 99999 --networks netmaker)
+	tokenJson=$(nmctl enrollment_key create --unlimited --networks netmaker)
 	TOKEN=$(jq -r '.token' <<< ${tokenJson})
 
 	wait_seconds 3

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -178,21 +178,6 @@ install_yq() {
 # setup_netclient - adds netclient to docker-compose
 setup_netclient() {
 
-
-	# yq ".services.netclient += {\"container_name\": \"netclient\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient += {\"image\": \"gravitl/netclient:$IMAGE_TAG\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient += {\"hostname\": \"netmaker-1\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient += {\"network_mode\": \"host\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient.depends_on += [\"netmaker\"]" -i /root/docker-compose.yml
-	# yq ".services.netclient += {\"restart\": \"always\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient.environment += {\"TOKEN\": \"$TOKEN\"}" -i /root/docker-compose.yml
-	# yq ".services.netclient.volumes += [\"/etc/netclient:/etc/netclient\"]" -i /root/docker-compose.yml
-	# yq ".services.netclient.cap_add += [\"NET_ADMIN\"]" -i /root/docker-compose.yml
-	# yq ".services.netclient.cap_add += [\"NET_RAW\"]" -i /root/docker-compose.yml
-	# yq ".services.netclient.cap_add += [\"SYS_MODULE\"]" -i /root/docker-compose.yml
-
-	# docker-compose up -d
-
 	set +e
 	netclient uninstall
 	set -e
@@ -200,7 +185,7 @@ setup_netclient() {
 	wget -O netclient https://github.com/gravitl/netclient/releases/download/$LATEST/netclient_linux_amd64
 	chmod +x netclient
 	./netclient install
-	netclient join -t $TOKEN
+	netclient register -t $TOKEN
 
 	echo "waiting for client to become available"
 	wait_seconds 10 
@@ -210,9 +195,9 @@ setup_netclient() {
 configure_netclient() {
 
 	NODE_ID=$(sudo cat /etc/netclient/nodes.yml | yq -r .netmaker.commonnode.id)
-	echo "join complete. New node ID: $NODE_ID"
+	echo "register complete. New node ID: $NODE_ID"
 	HOST_ID=$(sudo cat /etc/netclient/netclient.yml | yq -r .host.id)
-	echo "For first join, making host a default"
+	echo "making host a default"
 	echo "Host ID: $HOST_ID"
 	# set as a default host
 	set +e
@@ -660,11 +645,10 @@ setup_mesh() {
 
 	wait_seconds 5
 
-	echo "Creating netmaker access key"
+	echo "Creating netmaker enrollment key"
 
-	nmctl keys create test1 99999 --name netmaker-key
-	tokenJson=$(nmctl keys create netmaker 2)
-	TOKEN=$(jq -r '.accessstring' <<< ${tokenJson})
+	tokenJson=$(nmctl enrollment_key create --uses 99999 --networks netmaker)
+	TOKEN=$(jq -r '.token' <<< ${tokenJson})
 
 	wait_seconds 3
 

--- a/scripts/nm-upgrade.sh
+++ b/scripts/nm-upgrade.sh
@@ -427,20 +427,6 @@ test_caddy() {
 # setup_netclient - adds netclient to docker-compose
 setup_netclient() {
 
-  # yq ".services.netclient += {\"container_name\": \"netclient\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient += {\"image\": \"gravitl/netclient:testing\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient += {\"hostname\": \"netmaker-1\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient += {\"network_mode\": \"host\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient.depends_on += [\"netmaker\"]" -i /root/docker-compose.yml
-  # yq ".services.netclient += {\"restart\": \"always\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient.environment += {\"TOKEN\": \"$KEY\"}" -i /root/docker-compose.yml
-  # yq ".services.netclient.volumes += [\"/etc/netclient:/etc/netclient\"]" -i /root/docker-compose.yml
-  # yq ".services.netclient.cap_add += [\"NET_ADMIN\"]" -i /root/docker-compose.yml
-  # yq ".services.netclient.cap_add += [\"NET_RAW\"]" -i /root/docker-compose.yml
-  # yq ".services.netclient.cap_add += [\"SYS_MODULE\"]" -i /root/docker-compose.yml
-
-  # docker-compose up -d
-
 	set +e
 	netclient uninstall
 	set -e
@@ -449,7 +435,8 @@ setup_netclient() {
 
 	chmod +x /tmp/netclient
 	/tmp/netclient install
-	netclient join -t $KEY
+
+	netclient register -t $KEY
 
 	echo "waiting for client to become available"
 	wait_seconds 10 
@@ -520,11 +507,11 @@ join_networks() {
           confirm
 
           if [[ $NUM -eq 0 ]]; then 
-            echo "running command: ./nmctl keys create $NETWORK 1"
-            KEY_JSON=$(./nmctl keys create $NETWORK 1)          
-            KEY=$(echo $KEY_JSON | jq -r .accessstring)
+            echo "running command: ./nmctl enrollment_key create --uses 1 --networks $NETWORK"
+          	KEY_JSON=$(./nmctl enrollment_key create --uses 1 --networks $NETWORK)
+          	KEY=$(jq -r '.token' <<< ${KEY_JSON})
 
-            echo "join key created: $KEY"
+            echo "enrollment key created: $KEY"
 
             setup_netclient
           else


### PR DESCRIPTION
## Describe your changesRu

Modified nm-quick.sh and nm-upgrade.sh to use the registration key, instead of the access key.

## Provide Issue ticket number if applicable/not in title

GRA-1431

## Provide testing steps

1. Run nm-quick.sh on a fresh ubuntu server and install netmaker
2. Confirm install is successful
3. Wipe server, including any remnants of netclient
4. Run nm-quick-interactive.sh for 0.17.1
5. Add some networks and nodes
6. Run nm-upgrade.sh
7. Confirm that server is upgraded properly, running, and that there is a "default host" in all networks for netmaker-1 

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
