### PR TITLE
Remove ZeroSSL from Caddyfile

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,6 +1,6 @@
 {
         # ZeroSSL account
-        acme_ca https://acme.zerossl.com/v2/DV90
+        # acme_ca https://acme.zerossl.com/v2/DV90
         email YOUR_EMAIL
 }
 


### PR DESCRIPTION
## Describe your changes

There is an ongoing issue with ZeroSSL causing rate limiting: https://github.com/cert-manager/cert-manager/issues/5867

We should revert from ZeroSSL until this issue is resolved.

## Provide Issue ticket number if applicable/not in title

 https://github.com/gravitl/netmaker/issues/2129

## Provide testing steps

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
