### PR TITLE
bug: download nmcli for other architectures

### DIFF
--- a/scripts/nm-upgrade.sh
+++ b/scripts/nm-upgrade.sh
@@ -440,7 +440,7 @@ setup_netclient() {
 # setup_nmctl - pulls nmctl and makes it executable
 setup_nmctl() {
 
-    wget -O nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl_linux_amd64
+    wget -O nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl_linux_$(dpkg --print-architecture)
   
     chmod +x nmctl
     echo "using server $SERVER_HTTP_HOST"


### PR DESCRIPTION
## Describe your changes
Fix nm-upgrade.sh script to download correct arch nmcli binaries 
## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
