### PR TITLE
Fix netclient path for nm-quick.sh

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -182,7 +182,7 @@ setup_netclient() {
 	netclient uninstall
 	set -e
 
-	wget -O netclient https://github.com/gravitl/netclient/releases/download/$LATEST/netclient_linux_amd64
+	wget -O netclient https://github.com/gravitl/netclient/releases/download/$LATEST/netclient-linux-amd64
 	chmod +x netclient
 	./netclient install
 	netclient register -t $TOKEN


### PR DESCRIPTION
## Describe your changes

Fix nm-quick, which currently breaks by pointing to a nonexistent netclient.

netclient releases now use dashes: https://github.com/gravitl/netclient/releases

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
