### PR TITLE
Feature v0.18.6 nm quick script install path

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -704,52 +704,19 @@ print_success() {
 # 1. print netmaker logo
 print_logo
 
-
-
-set -e
-
-
 # 2. setup the build instructions
 set_buildinfo
 
-
-set -e
-
-
-
-
 # 3. get install dir, and make dir
 set_install_dir
-
-
-set -e
-
-
-
-
 
 set +e
 
 # 4. install necessary packages
 install_dependencies
 
-
-
-
-
-set -e
-
-
-
-
 # 5. install yq if necessary
 install_yq
-
-
-set -e
-
-
-
 
 # 6. if running a local build, clone git and build artifacts
 if [ "$BUILD_TYPE" = "local" ]; then
@@ -760,16 +727,6 @@ set -e
 
 # 7. get user input for variables
 set_install_vars
-
-
-
-
-
-set -e 
-
-
-
-
 
 # 8. get and set config files, startup docker-compose
 install_netmaker


### PR DESCRIPTION
## Describe your changes
Added functionality to the nm-quick.sh install script to set a custom install directory. defaults to /root if none provided or auto build is being used

## Provide Issue ticket number if applicable/not in title

## Provide testing steps
tested the script with building via version, branch, and local on versions v0.18.6 and v0.17.3 . tested a variation of autobuilding, versions and install directory left to default and set to a custom path.

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
