### PR TITLE
Update nm-quick.sh/nm-upgrade.sh with correct nmctl download path

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -210,7 +210,7 @@ configure_netclient() {
 # setup_nmctl - pulls nmctl and makes it executable
 setup_nmctl() {
 
-	wget -O /usr/bin/nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl_linux_amd64
+	wget -O /usr/bin/nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl-linux-amd64
 
     chmod +x /usr/bin/nmctl
     echo "using server api.$NETMAKER_BASE_DOMAIN"

--- a/scripts/nm-upgrade.sh
+++ b/scripts/nm-upgrade.sh
@@ -510,7 +510,7 @@ setup_netclient() {
 # setup_nmctl - pulls nmctl and makes it executable
 setup_nmctl() {
 
-    wget -O nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl_linux_amd64
+    wget -O nmctl https://github.com/gravitl/netmaker/releases/download/$LATEST/nmctl-linux-amd64
   
     chmod +x nmctl
     echo "using server $SERVER_HTTP_HOST"


### PR DESCRIPTION
## Describe your changes
Bad URL: https://github.com/gravitl/netmaker/releases/download/v0.18.7/nmctl_linux_amd64

Good URL: https://github.com/gravitl/netmaker/releases/download/v0.18.7/nmctl-linux-amd64

## Provide Issue ticket number if applicable/not in title
https://github.com/gravitl/netmaker/issues/2245

## Provide testing steps
Before:
```
> sudo wget -qO /root/nm-quick.sh https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/nm-quick.sh && sudo chmod +x /root/nm-quick.sh && sudo /root/nm-quick.sh
...
...
...
--2023-04-29 20:53:45--  https://github.com/gravitl/netmaker/releases/download/v0.18.7/nmctl_linux_amd64
Resolving github.com (github.com)... 192.30.255.113
Connecting to github.com (github.com)|192.30.255.113|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-04-29 20:53:45 ERROR 404: Not Found.
...
2023-04-29 20:54:01 (327 MB/s) - ‘netclient’ saved [13688832/13688832]

[netclient] 2023-04-29 20:54:01 setting OS
[netclient] 2023-04-29 20:54:01 setting version
[netclient] 2023-04-29 20:54:01 setting netclient hostid
[netclient] 2023-04-29 20:54:01 setting name
[netclient] 2023-04-29 20:54:01 setting macAddress
[netclient] 2023-04-29 20:54:01 setting wireguard keys
[netclient] 2023-04-29 20:54:01 setting wireguard interface
[netclient] 2023-04-29 20:54:01 setting listenport
[netclient] 2023-04-29 20:54:01 setting proxyListenPort
[netclient] 2023-04-29 20:54:01 setting MTU
[netclient] 2023-04-29 20:54:01 setting traffic keys
2023/04/29 20:54:01 calling systemctl stop netclient
Error: flag needs an argument: 't' in -t
Usage:
  netclient register [flags]

Flags:
  -A, --all-networks    attempts to register to all available networks to user
  -h, --help            help for register
  -n, --net string      network to attempt to register to
  -s, --server string   server for attempting SSO/Auth registration
  -t, --token string    enrollment token for registering to a Netmaker instance
  -u, --user string     user name for attempting Basic Auth registration

Global Flags:
  -v, --verbosity int   set logging verbosity 0-4
```

Now things should work.

## Checklist before requesting a review
- [X] My changes affect only 10 files or less.
- [X] I have performed a self-review of my code and tested it.
- [X] If it is a bugfix, my code is <= 200 lines.
- [X] Netmaker is awesome.
