### PR TITLE
update develop (#2319)

### DIFF
--- a/scripts/nm-certs.sh
+++ b/scripts/nm-certs.sh
@@ -54,7 +54,8 @@ chmod +x zerossl-bot.sh
 # request the certs
 ./zerossl-bot.sh "$CERTBOT_PARAMS"
 EOF
-chmod +x certbot-entry.sh
+
+chmod +x "$SCRIPT_DIR/certbot-entry.sh"
 
 # request certs
 sudo docker run -it --rm --name certbot \
@@ -73,7 +74,6 @@ if [ ! -f "$CERT_DIR"/fullchain.pem ]; then
 	sudo docker run -it --rm --name certbot \
 		-p 80:80 -p 443:443 \
 		-v "$SCRIPT_DIR/letsencrypt:/etc/letsencrypt" \
-		--entrypoint "/opt/certbot/certbot-entry.sh" \
 		certbot/certbot "$CERTBOT_PARAMS"
 	if [ ! -f "$CERT_DIR"/fullchain.pem ]; then
 		echo "Missing file: $CERT_DIR/fullchain.pem"


### PR DESCRIPTION
* Release v0.20.0 (#2304)

* free tier limit exceeded: status code now 403

* reformat, TODOs

* - nm-certs for zerossl
- added config for email, domain
- updated linux deps

* return {} if no records found for acls/metrics

* Revert "return {} if no records found for acls/metrics"

pushed to wrong branch
This reverts commit 7602e97950a178b141a46bb872dd43e200951e08.

* return {} if no records found for acls/metrics

* add type to enrollement key

* add type to enrollement key

* update version

* - request and mount certs
- handle caddy challenge
- docker fixes
- pull nm-certs.sh

* Revert "add type to enrollement key"

This reverts commit 0cf342dd6e5dcbc1a3b3962350e6dcb7739380df.

* nm-certs.sh
- support EE and new domains
- minor fixes

* shfmt reformat

* add type to APIEnrollementKey

* if -- else to determine type

* spellcheck

* - support EE
- config namespaces
- write config after confirm
- minor fixes

* nm-certs.sh
- config fixes
- crontab symlink

* release workflows

* use forked repo

* Revert "use forked repo"

This reverts commit 730aca7ed88bc01ffbd4c2a66a2e429aafd82da6.

* - fixes
- user msgs

* review comments

* Bump github.com/txn2/txeh from 1.3.0 to 1.4.0

Bumps [github.com/txn2/txeh](https://github.com/txn2/txeh) from 1.3.0 to 1.4.0.
- [Release notes](https://github.com/txn2/txeh/releases)
- [Changelog](https://github.com/txn2/txeh/blob/master/goreleaser.yml)
- [Commits](https://github.com/txn2/txeh/compare/v1.3.0...v1.4.0)

---
updated-dependencies:
- dependency-name: github.com/txn2/txeh dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump alpine from 3.17.2 to 3.17.3

Bumps alpine from 3.17.2 to 3.17.3.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-patch ...



* - nm-certs.sh switched to dockerized certbot
- nm-quick.sh removed certbot from deps

* fixed missing domain

* - shallow clone for local installs
- added certs to other compose files

* missing domain, auto ToS

* fallback to letsencrypt

* removed turris OS

* fix typo

* send host update when deleting relay

* fixed shallow clone for branches

* disable cleanup for tests

* fixed local install

* - fixed cert mounting
- fixed caddy restart in nm-certs.sh
- aligned all configs

* fixed caddy start/stop

* - added NM_SKIP_BUILD
- fixed docker stop

* fixed NM_SKIP_BUILD

* - fixed ServerBrokerEndpoint config (#2283)

- mq credentials in compose

* NET-129: Turn Signal Actions (#2290)

* add signal action field

* add negotiation signal action

* typo fix

* change signal action name

* NET-147 full config for nm-quick.sh (#2291)

* - moved all vars to config
- compose override
- use the config in compose, caddy
- aligned local / remote setup
- proper docker cleanup
- support for a relative installation path

* - config handling
- error handling / env cleanups
- reduced compose files
- misc

* fixed debugs

* fixed UI_IMAGE_TAG / IMAGE_TAG

* Bump alpine from 3.17.3 to 3.18.0 (#2299)

Bumps alpine from 3.17.3 to 3.18.0.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump golang.org/x/crypto from 0.8.0 to 0.9.0 (#2298)

Bumps [golang.org/x/crypto](https://github.com/golang/crypto) from 0.8.0 to 0.9.0.
- [Commits](https://github.com/golang/crypto/compare/v0.8.0...v0.9.0)

---
updated-dependencies:
- dependency-name: golang.org/x/crypto dependency-type: direct:production update-type: version-update:semver-minor ...




* Extclient NET-63x (#2286)

* model changes

* additional fields for extclient create

* add DNS to extclient config

* extclient name checks

* update extclient

* nmctl extclient

* final tweaks

* review comments

* add extclientdns to node on ingress creation

* fix to add ingress dns to api (#2296)

---------



* versions (#2302)

* Bump golang.org/x/oauth2 from 0.7.0 to 0.8.0 (#2297)

Bumps [golang.org/x/oauth2](https://github.com/golang/oauth2) from 0.7.0 to 0.8.0.
- [Commits](https://github.com/golang/oauth2/compare/v0.7.0...v0.8.0)

---
updated-dependencies:
- dependency-name: golang.org/x/oauth2 dependency-type: direct:production update-type: version-update:semver-minor ...




---------








* nm-certs permission (#2305)

* quotes (#2309)

* Release v0.20.0 (#2317)

* free tier limit exceeded: status code now 403

* reformat, TODOs

* - nm-certs for zerossl
- added config for email, domain
- updated linux deps

* return {} if no records found for acls/metrics

* Revert "return {} if no records found for acls/metrics"

pushed to wrong branch
This reverts commit 7602e97950a178b141a46bb872dd43e200951e08.

* return {} if no records found for acls/metrics

* add type to enrollement key

* add type to enrollement key

* update version

* - request and mount certs
- handle caddy challenge
- docker fixes
- pull nm-certs.sh

* Revert "add type to enrollement key"

This reverts commit 0cf342dd6e5dcbc1a3b3962350e6dcb7739380df.

* nm-certs.sh
- support EE and new domains
- minor fixes

* shfmt reformat

* add type to APIEnrollementKey

* if -- else to determine type

* spellcheck

* - support EE
- config namespaces
- write config after confirm
- minor fixes

* nm-certs.sh
- config fixes
- crontab symlink

* release workflows

* use forked repo

* Revert "use forked repo"

This reverts commit 730aca7ed88bc01ffbd4c2a66a2e429aafd82da6.

* - fixes
- user msgs

* review comments

* Bump github.com/txn2/txeh from 1.3.0 to 1.4.0

Bumps [github.com/txn2/txeh](https://github.com/txn2/txeh) from 1.3.0 to 1.4.0.
- [Release notes](https://github.com/txn2/txeh/releases)
- [Changelog](https://github.com/txn2/txeh/blob/master/goreleaser.yml)
- [Commits](https://github.com/txn2/txeh/compare/v1.3.0...v1.4.0)

---
updated-dependencies:
- dependency-name: github.com/txn2/txeh dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump alpine from 3.17.2 to 3.17.3

Bumps alpine from 3.17.2 to 3.17.3.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-patch ...



* - nm-certs.sh switched to dockerized certbot
- nm-quick.sh removed certbot from deps

* fixed missing domain

* - shallow clone for local installs
- added certs to other compose files

* missing domain, auto ToS

* fallback to letsencrypt

* removed turris OS

* fix typo

* send host update when deleting relay

* fixed shallow clone for branches

* disable cleanup for tests

* fixed local install

* - fixed cert mounting
- fixed caddy restart in nm-certs.sh
- aligned all configs

* fixed caddy start/stop

* - added NM_SKIP_BUILD
- fixed docker stop

* fixed NM_SKIP_BUILD

* - fixed ServerBrokerEndpoint config (#2283)

- mq credentials in compose

* NET-129: Turn Signal Actions (#2290)

* add signal action field

* add negotiation signal action

* typo fix

* change signal action name

* NET-147 full config for nm-quick.sh (#2291)

* - moved all vars to config
- compose override
- use the config in compose, caddy
- aligned local / remote setup
- proper docker cleanup
- support for a relative installation path

* - config handling
- error handling / env cleanups
- reduced compose files
- misc

* fixed debugs

* fixed UI_IMAGE_TAG / IMAGE_TAG

* Bump alpine from 3.17.3 to 3.18.0 (#2299)

Bumps alpine from 3.17.3 to 3.18.0.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump golang.org/x/crypto from 0.8.0 to 0.9.0 (#2298)

Bumps [golang.org/x/crypto](https://github.com/golang/crypto) from 0.8.0 to 0.9.0.
- [Commits](https://github.com/golang/crypto/compare/v0.8.0...v0.9.0)

---
updated-dependencies:
- dependency-name: golang.org/x/crypto dependency-type: direct:production update-type: version-update:semver-minor ...




* Extclient NET-63x (#2286)

* model changes

* additional fields for extclient create

* add DNS to extclient config

* extclient name checks

* update extclient

* nmctl extclient

* final tweaks

* review comments

* add extclientdns to node on ingress creation

* fix to add ingress dns to api (#2296)

---------



* versions (#2302)

* Bump golang.org/x/oauth2 from 0.7.0 to 0.8.0 (#2297)

Bumps [golang.org/x/oauth2](https://github.com/golang/oauth2) from 0.7.0 to 0.8.0.
- [Commits](https://github.com/golang/oauth2/compare/v0.7.0...v0.8.0)

---
updated-dependencies:
- dependency-name: golang.org/x/oauth2 dependency-type: direct:production update-type: version-update:semver-minor ...




* Fixed nm-certs relative path (#2311)

* nm-certs permission (#2308)

* nm-certs permission

* single quotes error

* fixed relative path

---------



---------









---------

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
