### PR TITLE
WIP: NET-238 Fast local builds

### DIFF
--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -7,6 +7,7 @@ Dev scripts for Netmaker
 Creates tunnels between a local instance and a docker-compose deployment on a droplet. Allows for fast local builds and local debugging.
 
 Steps:
+1. Consider migrating the DB (see below)
 1. Create 2 ssh hosts in `~/.ssh/config` (adjust `DROPLET` and `IP`):
 ```
 Host DROPLET
@@ -23,7 +24,7 @@ Host DROPLET-docker-netmaker
     RequestTTY no
     RemoteCommand cat
 ```
-2. Copy [./scripts/dev/docker-compose.override.yml](./docker-compose.override.yml) to the installation dir on DROPLET (merge if already exists)
+2. Copy [./scripts/dev/docker-compose.override.yml](docker-compose.override.yml) to the installation dir on DROPLET (merge if already exists)
 3. `docker-compose down`
 4. `docker-compose up --force-recreate`
 5. `./scripts/dev/tunnel-compose.sh DROPLET-docker-netmaker`
@@ -31,3 +32,22 @@ Host DROPLET-docker-netmaker
   `MQ_PASSWORD=SECRET;MQ_USERNAME=netmaker;SERVER_BROKER_ENDPOINT=ws://localhost:1883;VERBOSE=3`
 
 At this point tunnels should be set up and running a local build should talk to the docker-compose services on the droplet.
+
+
+### DB migration
+
+**Option 1** - run docker-compose (WITHOUT the override) and copy the existing DB: 
+```bash
+# on the droplet
+docker-compose up --force-recreate netmaker
+docker cp netmaker:/data/netmaker.db .
+# on the host
+scp DROPLET:netmaker.db data 
+```
+
+**Option 2** (CE ONLY) - re-run nm-quick (WITH the override) to re-create the DB:
+```bash
+wget https://raw.githubusercontent.com/gravitl/netmaker/NET-246/read-def-config/scripts/nm-quick.sh
+chmod +x nm-quick.sh
+env NM_SKIP_BUILD=1 ./nm-quick.sh -b local -t BRANCH_NAME
+```

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -45,7 +45,7 @@ docker cp netmaker:/data/netmaker.db .
 scp DROPLET:netmaker.db data 
 ```
 
-**Option 2** (CE ONLY) - re-run nm-quick (WITH the override) to re-create the DB:
+**Option 2** (CE ONLY) - re-run nm-quick (WITH the override and a running local server) to re-create the DB:
 ```bash
 wget https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/nm-quick.sh
 chmod +x nm-quick.sh

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,33 @@
+# Dev Scripts
+
+Dev scripts for Netmaker
+
+## Tunnel Compose
+
+Creates tunnels between a local instance and a docker-compose deployment on a droplet. Allows for fast local builds and local debugging.
+
+Steps:
+1. Create 2 ssh hosts in `~/.ssh/config` (adjust `DROPLET` and `IP`):
+```
+Host DROPLET
+    User root
+    Hostname IP
+
+Host DROPLET-docker-netmaker
+    User user
+    Hostname localhost
+    Port 2222
+    ProxyJump DROPLET
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
+    RequestTTY no
+    RemoteCommand cat
+```
+2. Copy [./scripts/dev/docker-compose.override.yml](./docker-compose.override.yml) to the installation dir on DROPLET (merge if already exists)
+3. `docker-compose down`
+4. `docker-compose up --force-recreate`
+5. `./scripts/dev/tunnel-compose.sh DROPLET-docker-netmaker`
+6. Add env vars to the local build (include a password from the droplet), eg:
+  `MQ_PASSWORD=SECRET;MQ_USERNAME=netmaker;SERVER_BROKER_ENDPOINT=ws://localhost:1883;VERBOSE=3`
+
+At this point tunnels should be set up and running a local build should talk to the docker-compose services on the droplet.

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -28,8 +28,8 @@ Host DROPLET-docker-netmaker
 3. `docker-compose down`
 4. `docker-compose up --force-recreate`
 5. `./scripts/dev/tunnel-compose.sh DROPLET-docker-netmaker`
-6. Add env vars to the local build (include a password from the droplet), eg:
-  `MQ_PASSWORD=SECRET;MQ_USERNAME=netmaker;SERVER_BROKER_ENDPOINT=ws://localhost:1883;VERBOSE=3`
+6. Add env vars to the local build (include `MQ_PASSWORD` from the droplet), eg:<br />
+    `MQ_PASSWORD=SECRET;MQ_USERNAME=netmaker;SERVER_BROKER_ENDPOINT=ws://localhost:1883;VERBOSE=3`
 
 At this point tunnels should be set up and running a local build should talk to the docker-compose services on the droplet.
 
@@ -47,7 +47,7 @@ scp DROPLET:netmaker.db data
 
 **Option 2** (CE ONLY) - re-run nm-quick (WITH the override) to re-create the DB:
 ```bash
-wget https://raw.githubusercontent.com/gravitl/netmaker/NET-246/read-def-config/scripts/nm-quick.sh
+wget https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/nm-quick.sh
 chmod +x nm-quick.sh
 env NM_SKIP_BUILD=1 ./nm-quick.sh -b local -t BRANCH_NAME
 ```

--- a/scripts/dev/docker-compose.override.yml
+++ b/scripts/dev/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: "3.4"
+
+services:
+
+  netmaker:
+    image: linuxserver/openssh-server
+    environment:
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=123123
+      - USER_NAME=user
+      - SUDO_ACCESS=true
+      - DOCKER_MODS=linuxserver/mods:openssh-server-ssh-tunnel
+    ports:
+      - "2222:2222"

--- a/scripts/dev/docker-compose.override.yml
+++ b/scripts/dev/docker-compose.override.yml
@@ -11,4 +11,4 @@ services:
       - SUDO_ACCESS=true
       - DOCKER_MODS=linuxserver/mods:openssh-server-ssh-tunnel
     ports:
-      - "2222:2222"
+      - "127.0.0.1:2222:2222"

--- a/scripts/dev/tunnel-compose.sh
+++ b/scripts/dev/tunnel-compose.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+SSH_HOST=$1
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+source "$SCRIPT_DIR/../netmaker.env"
+
+# TODO read 1883 from SERVER_BROKER_ENDPOINT
+# $API_PORT 8081
+sshpass -p123123 ssh $SSH_HOST \
+	-R 0.0.0.0:$API_PORT:localhost:$API_PORT \
+	-L 1883:mq:1883 \
+	-N -vv
+
+	# TODO UDP fwd 3478
+	#-R $STUN_PORT:localhost:$STUN_PORT


### PR DESCRIPTION
## Describe your changes

Developer only.

Creates tunnels between a local instance and a docker-compose deployment on a droplet. Allows for fast local builds and local debugging.

More information [in the readme](https://github.com/gravitl/netmaker/tree/NET-238/fast-local-builds/scripts/dev).