### PR TITLE
NET 284 - Don't expose user hashed password

### DIFF
--- a/logic/auth.go
+++ b/logic/auth.go
@@ -42,20 +42,6 @@ func HasAdmin() (bool, error) {
 	return false, err
 }
 
-// GetReturnUser - gets a user
-func GetReturnUser(username string) (models.ReturnUser, error) {
-
-	var user models.ReturnUser
-	record, err := database.FetchRecord(database.USERS_TABLE_NAME, username)
-	if err != nil {
-		return user, err
-	}
-	if err = json.Unmarshal([]byte(record), &user); err != nil {
-		return models.ReturnUser{}, err
-	}
-	return user, err
-}
-
 // GetUsers - gets users
 func GetUsers() ([]models.ReturnUser, error) {
 

--- a/logic/users.go
+++ b/logic/users.go
@@ -26,6 +26,30 @@ func GetUser(username string) (*models.User, error) {
 	return &user, err
 }
 
+// GetReturnUser - gets a user
+func GetReturnUser(username string) (models.ReturnUser, error) {
+
+	var user models.ReturnUser
+	record, err := database.FetchRecord(database.USERS_TABLE_NAME, username)
+	if err != nil {
+		return user, err
+	}
+	if err = json.Unmarshal([]byte(record), &user); err != nil {
+		return models.ReturnUser{}, err
+	}
+	return user, err
+}
+
+// ToReturnUser - gets a user as a return user
+func ToReturnUser(user models.User) models.ReturnUser {
+	return models.ReturnUser{
+		UserName: user.UserName,
+		Networks: user.Networks,
+		IsAdmin:  user.IsAdmin,
+		Groups:   user.Groups,
+	}
+}
+
 // GetGroupUsers - gets users in a group
 func GetGroupUsers(group string) ([]models.ReturnUser, error) {
 	var returnUsers []models.ReturnUser


### PR DESCRIPTION
## Describe your changes

Behavior before:
Calling PUT to netmaker /api/users/networks/{username} for example returned user password hash, it happened for some other routes in the same file of the handler too.

Behavior now:
Now we use a proper struct on those handlers responses which doesn't include the password

## Provide testing steps

## Checklist before requesting a review
- [X] My changes affect only 10 files or less.
- [X] I have performed a self-review of my code and tested it.
- [X] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [X] If it is a bugfix, my code is <= 200 lines.
- [X] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [X] My unit tests pass locally.
- [X] Netmaker is awesome.
