### PR TITLE
Revert "prevent ingress creation on NATed host"

### DIFF
--- a/logic/gateway.go
+++ b/logic/gateway.go
@@ -115,9 +115,6 @@ func CreateIngressGateway(netid string, nodeid string, ingress models.IngressReq
 	if host.FirewallInUse == models.FIREWALL_NONE {
 		return models.Node{}, errors.New("firewall is not supported for ingress gateways")
 	}
-	if host.NatType != models.NAT_Types.Public {
-		return models.Node{}, errors.New("ingress cannot be created on nodes behind NAT")
-	}
 
 	network, err := GetParentNetwork(netid)
 	if err != nil {


### PR DESCRIPTION
Reverts gravitl/netmaker#2395

Reason: check [ticket](https://toil.kitemaker.co/cQARgD-Gravitl/6a50SD-Netmaker/items/379)
