### PR TITLE
nm-quick netmaker edition upgrade fix

### DIFF
--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -43,6 +43,7 @@ while getopts evab:d:t: flag; do
 	case "${flag}" in
 	e)
 		INSTALL_TYPE="ee"
+		UPGRADE_FLAG="yes"
 		;;
 	v)
 		usage
@@ -880,6 +881,9 @@ print_logo
 if [ -f "$CONFIG_PATH" ]; then
 	echo "Using config: $CONFIG_PATH"
 	source "$CONFIG_PATH"
+	if [ "$UPGRADE_FLAG" = "yes" ]; then
+		INSTALL_TYPE="ee"
+	fi
 fi
 
 # 2. setup the build instructions


### PR DESCRIPTION
## Describe your changes
nm-quick netmaker edition upgrade fix.

## Provide Issue ticket number if applicable/not in title

## Provide testing steps
Install Netmaker CE using the nm-quick.sh script. After that try to upgrade it to Netmaker EE by using nm-quick.sh with the "-e" flag set. For example -> sudo nm-quick.sh -e

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
