### PR TITLE
NET-427: Peer Update fixes

### DIFF
--- a/controllers/hosts.go
+++ b/controllers/hosts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/logic"
-	"github.com/gravitl/netmaker/logic/hostactions"
 	"github.com/gravitl/netmaker/models"
 	"github.com/gravitl/netmaker/mq"
 	"github.com/gravitl/netmaker/servercfg"
@@ -259,18 +258,13 @@ func addHostToNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Log(1, "added new node", newNode.ID.String(), "to host", currHost.Name)
-	hostactions.AddAction(models.HostUpdate{
+
+	mq.HostUpdate(&models.HostUpdate{
 		Action: models.JoinHostToNetwork,
 		Host:   *currHost,
 		Node:   *newNode,
 	})
-	if servercfg.IsMessageQueueBackend() {
-		mq.HostUpdate(&models.HostUpdate{
-			Action: models.RequestAck,
-			Host:   *currHost,
-		})
-	}
-
+	go mq.PublishPeerUpdate()
 	logger.Log(2, r.Header.Get("user"), fmt.Sprintf("added host %s to network %s", currHost.Name, network))
 	w.WriteHeader(http.StatusOK)
 }
@@ -309,6 +303,25 @@ func deleteHostFromNetwork(w http.ResponseWriter, r *http.Request) {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))
 		return
 	}
+	if node.IsRelayed {
+		// cleanup node from relayednodes on relay node
+		relayNode, err := logic.GetNodeByID(node.RelayedBy)
+		if err == nil {
+			relayedNodes := []string{}
+			for _, relayedNodeID := range relayNode.RelayedNodes {
+				if relayedNodeID == node.ID.String() {
+					continue
+				}
+				relayedNodes = append(relayedNodes, relayedNodeID)
+			}
+			relayNode.RelayedNodes = relayedNodes
+			logic.UpsertNode(&relayNode)
+		}
+	}
+	if node.IsRelay {
+		// unset all the relayed nodes
+		logic.SetRelayedNodes(false, node.ID.String(), node.RelayedNodes)
+	}
 	node.Action = models.NODE_DELETE
 	node.PendingDelete = true
 	logger.Log(1, "deleting  node", node.ID.String(), "from host", currHost.Name)
@@ -317,10 +330,10 @@ func deleteHostFromNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// notify node change
-
 	runUpdates(node, false)
 	go func() { // notify of peer change
-		if err := mq.PublishPeerUpdate(); err != nil {
+		err = mq.PublishDeletedNodePeerUpdate(node)
+		if err != nil {
 			logger.Log(1, "error publishing peer update ", err.Error())
 		}
 		if err := mq.PublishDNSDelete(node, currHost); err != nil {

--- a/controllers/hosts.go
+++ b/controllers/hosts.go
@@ -258,13 +258,14 @@ func addHostToNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Log(1, "added new node", newNode.ID.String(), "to host", currHost.Name)
-
-	mq.HostUpdate(&models.HostUpdate{
-		Action: models.JoinHostToNetwork,
-		Host:   *currHost,
-		Node:   *newNode,
-	})
-	go mq.PublishPeerUpdate()
+	go func() {
+		mq.HostUpdate(&models.HostUpdate{
+			Action: models.JoinHostToNetwork,
+			Host:   *currHost,
+			Node:   *newNode,
+		})
+		mq.PublishPeerUpdate()
+	}()
 	logger.Log(2, r.Header.Get("user"), fmt.Sprintf("added host %s to network %s", currHost.Name, network))
 	w.WriteHeader(http.StatusOK)
 }

--- a/controllers/node.go
+++ b/controllers/node.go
@@ -754,7 +754,6 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 			relayNode.RelayedNodes = relayedNodes
 			logic.UpsertNode(&relayNode)
 		}
-
 	}
 	if node.IsRelay {
 		// unset all the relayed nodes
@@ -770,9 +769,9 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 	if !fromNode { // notify node change
 		runUpdates(&node, false)
 	}
-	go func(deletedNode *models.Node) { // notify of peer change
+	go func() { // notify of peer change
 		var err error
-		err = mq.PublishDeletedNodePeerUpdate(deletedNode)
+		err = mq.PublishDeletedNodePeerUpdate(&node)
 		if err != nil {
 			logger.Log(1, "error publishing peer update ", err.Error())
 		}
@@ -783,7 +782,7 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 		if err := mq.PublishDNSDelete(&node, host); err != nil {
 			logger.Log(1, "error publishing dns update", err.Error())
 		}
-	}(&node)
+	}()
 }
 
 func runUpdates(node *models.Node, ifaceDelta bool) {

--- a/controllers/node.go
+++ b/controllers/node.go
@@ -770,17 +770,12 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 	if !fromNode { // notify node change
 		runUpdates(&node, false)
 	}
-	go func(deletedNode *models.Node, fromNode bool) { // notify of peer change
+	go func(deletedNode *models.Node) { // notify of peer change
 		var err error
-		if fromNode {
-			err = mq.PublishDeletedNodePeerUpdate(deletedNode)
-		} else {
-			err = mq.PublishPeerUpdate()
-		}
+		err = mq.PublishDeletedNodePeerUpdate(deletedNode)
 		if err != nil {
 			logger.Log(1, "error publishing peer update ", err.Error())
 		}
-
 		host, err := logic.GetHost(node.HostID.String())
 		if err != nil {
 			logger.Log(1, "failed to retrieve host for node", node.ID.String(), err.Error())
@@ -788,7 +783,7 @@ func deleteNode(w http.ResponseWriter, r *http.Request) {
 		if err := mq.PublishDNSDelete(&node, host); err != nil {
 			logger.Log(1, "error publishing dns update", err.Error())
 		}
-	}(&node, fromNode)
+	}(&node)
 }
 
 func runUpdates(node *models.Node, ifaceDelta bool) {

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -312,7 +312,6 @@ func GetPeerUpdateForHost(network string, host *models.Host, allNodes []models.N
 				}
 				hostPeerUpdate.NodePeers = append(hostPeerUpdate.NodePeers, nodePeer)
 			}
-			//}
 		}
 		var extPeers []wgtypes.PeerConfig
 		var extPeerIDAndAddrs []models.IDandAddr
@@ -386,6 +385,18 @@ func GetPeerUpdateForHost(network string, host *models.Host, allNodes []models.N
 			peer.Remove = true
 		}
 		hostPeerUpdate.Peers[i] = peer
+	}
+	if deletedNode != nil {
+		peerHost, err := GetHost(deletedNode.HostID.String())
+		if err == nil && host.ID != peerHost.ID {
+			if _, ok := peerIndexMap[peerHost.PublicKey.String()]; !ok {
+				hostPeerUpdate.Peers = append(hostPeerUpdate.Peers, wgtypes.PeerConfig{
+					PublicKey: peerHost.PublicKey,
+					Remove:    true,
+				})
+			}
+		}
+
 	}
 
 	for i := range hostPeerUpdate.NodePeers {


### PR DESCRIPTION
## Describe your changes

-  Send delete peer update even when the host is unresponsive
-  Unrelay nodes when relay node is deleted from a network via UI
-  send peer update when host is added to network

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

- [x] Add/remove the host from a network via UI, check if other peers are updated accordingly
- [x] Leave a network using netclient, check if the peer is deleted from the other peers interfaces
- [x] Relay a node and delete the relay node from the network while it's relaying a node, check if a relayed node gets un-relayed and have the right peers on the interface

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
