### PR TITLE
[NET-353] Solve race condition with "unique" ips

### DIFF
--- a/logic/extpeers.go
+++ b/logic/extpeers.go
@@ -150,7 +150,6 @@ func GetExtClientByPubKey(publicKey string, network string) (*models.ExtClient, 
 
 // CreateExtClient - creates an extclient
 func CreateExtClient(extclient *models.ExtClient) error {
-
 	// lock because we need unique IPs and having it concurrent makes parallel calls result in same "unique" IPs
 	addressLock.Lock()
 	defer addressLock.Unlock()

--- a/logic/extpeers.go
+++ b/logic/extpeers.go
@@ -151,6 +151,10 @@ func GetExtClientByPubKey(publicKey string, network string) (*models.ExtClient, 
 // CreateExtClient - creates an extclient
 func CreateExtClient(extclient *models.ExtClient) error {
 
+	// lock because we need unique IPs and having it concurrent makes parallel calls result in same "unique" IPs
+	addressLock.Lock()
+	defer addressLock.Unlock()
+
 	if len(extclient.PublicKey) == 0 {
 		privateKey, err := wgtypes.GeneratePrivateKey()
 		if err != nil {

--- a/logic/networks.go
+++ b/logic/networks.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/c-robinson/iplib"
 	validator "github.com/go-playground/validator/v10"
@@ -147,8 +148,13 @@ func GetNetworkSettings(networkname string) (models.Network, error) {
 	return network, nil
 }
 
-// UniqueAddress - see if address is unique
+// UniqueAddress - get a unique ipv4 address
 func UniqueAddress(networkName string, reverse bool) (net.IP, error) {
+
+	// getting unique addresses procedures are mutually exclusive
+	addressLock.Lock()
+	defer addressLock.Unlock()
+
 	add := net.IP{}
 	var network models.Network
 	network, err := GetParentNetwork(networkName)
@@ -236,6 +242,11 @@ func IsIPUnique(network string, ip string, tableName string, isIpv6 bool) bool {
 
 // UniqueAddress6 - see if ipv6 address is unique
 func UniqueAddress6(networkName string, reverse bool) (net.IP, error) {
+
+	// getting unique addresses procedures are mutually exclusive
+	addressLock.Lock()
+	defer addressLock.Unlock()
+
 	add := net.IP{}
 	var network models.Network
 	network, err := GetParentNetwork(networkName)
@@ -424,3 +435,9 @@ func SortNetworks(unsortedNetworks []models.Network) {
 }
 
 // == Private ==
+
+var addressLock sync.Locker
+
+func init() {
+	addressLock = &sync.Mutex{}
+}

--- a/logic/networks.go
+++ b/logic/networks.go
@@ -426,8 +426,4 @@ func SortNetworks(unsortedNetworks []models.Network) {
 
 // == Private ==
 
-var addressLock sync.Locker
-
-func init() {
-	addressLock = &sync.Mutex{}
-}
+var addressLock = &sync.Mutex{}

--- a/logic/networks.go
+++ b/logic/networks.go
@@ -151,10 +151,6 @@ func GetNetworkSettings(networkname string) (models.Network, error) {
 // UniqueAddress - get a unique ipv4 address
 func UniqueAddress(networkName string, reverse bool) (net.IP, error) {
 
-	// getting unique addresses procedures are mutually exclusive
-	addressLock.Lock()
-	defer addressLock.Unlock()
-
 	add := net.IP{}
 	var network models.Network
 	network, err := GetParentNetwork(networkName)
@@ -242,10 +238,6 @@ func IsIPUnique(network string, ip string, tableName string, isIpv6 bool) bool {
 
 // UniqueAddress6 - see if ipv6 address is unique
 func UniqueAddress6(networkName string, reverse bool) (net.IP, error) {
-
-	// getting unique addresses procedures are mutually exclusive
-	addressLock.Lock()
-	defer addressLock.Unlock()
 
 	add := net.IP{}
 	var network models.Network

--- a/logic/networks.go
+++ b/logic/networks.go
@@ -150,7 +150,6 @@ func GetNetworkSettings(networkname string) (models.Network, error) {
 
 // UniqueAddress - get a unique ipv4 address
 func UniqueAddress(networkName string, reverse bool) (net.IP, error) {
-
 	add := net.IP{}
 	var network models.Network
 	network, err := GetParentNetwork(networkName)
@@ -238,7 +237,6 @@ func IsIPUnique(network string, ip string, tableName string, isIpv6 bool) bool {
 
 // UniqueAddress6 - see if ipv6 address is unique
 func UniqueAddress6(networkName string, reverse bool) (net.IP, error) {
-
 	add := net.IP{}
 	var network models.Network
 	network, err := GetParentNetwork(networkName)

--- a/logic/nodes.go
+++ b/logic/nodes.go
@@ -460,7 +460,6 @@ func updateProNodeACLS(node *models.Node) error {
 
 // createNode - creates a node in database
 func createNode(node *models.Node) error {
-
 	// lock because we need unique IPs and having it concurrent makes parallel calls result in same "unique" IPs
 	addressLock.Lock()
 	defer addressLock.Unlock()

--- a/logic/nodes.go
+++ b/logic/nodes.go
@@ -460,6 +460,11 @@ func updateProNodeACLS(node *models.Node) error {
 
 // createNode - creates a node in database
 func createNode(node *models.Node) error {
+
+	// lock because we need unique IPs and having it concurrent makes parallel calls result in same "unique" IPs
+	addressLock.Lock()
+	defer addressLock.Unlock()
+
 	host, err := GetHost(node.HostID.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes

Makes the procedure of getting-and-setting unique ips to new nodes and extclients atomic and mutually exclusive by using a lock.

Closes #2356 

## Provide testing steps

1. create two or more nodes simultaneously (create a script that calls the api in parallel goroutines?)
2. run this test a few times (the error has a <100% probability of occurring)

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
