### PR TITLE
NET-505: use local port for metrics pinger

### DIFF
--- a/logic/peers.go
+++ b/logic/peers.go
@@ -240,7 +240,7 @@ func GetPeerUpdateForHost(network string, host *models.Host, allNodes []models.N
 					Address:    peer.PrimaryAddress(),
 					Name:       peerHost.Name,
 					Network:    peer.Network,
-					ListenPort: GetPeerListenPort(peerHost),
+					ListenPort: peerHost.ListenPort,
 				}
 				hostPeerUpdate.NodePeers = append(hostPeerUpdate.NodePeers, nodePeer)
 			}


### PR DESCRIPTION
## Describe your changes
-> metrics pinger should use local interface port
## Provide Issue ticket number if applicable/not in title

## Provide testing steps

- [ ] For a device behind NAT verify if the metrics is collected as expected on the client

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
