### PR TITLE
NET-513

### DIFF
--- a/scripts/nm-certs.sh
+++ b/scripts/nm-certs.sh
@@ -27,20 +27,34 @@ if [ -n "$(docker ps | grep caddy)" ]; then
 	docker-compose -f /root/docker-compose.yml stop caddy
 fi
 
-CERTBOT_PARAMS=$(cat <<EOF
-certonly --standalone \
-	--non-interactive --agree-tos \
-	-m $NM_EMAIL \
-	-d api.$NM_DOMAIN \
-	-d broker.$NM_DOMAIN \
-	-d dashboard.$NM_DOMAIN \
-	-d turn.$NM_DOMAIN \
-	-d turnapi.$NM_DOMAIN \
-	-d netmaker-exporter.$NM_DOMAIN \
-	-d grafana.$NM_DOMAIN \
-	-d prometheus.$NM_DOMAIN
+if [ "$INSTALL_TYPE" = "ce" ]; then
+	CERTBOT_PARAMS=$(cat <<EOF
+	certonly --standalone \
+		--non-interactive --agree-tos \
+		-m $NM_EMAIL \
+		-d api.$NM_DOMAIN \
+		-d broker.$NM_DOMAIN \
+		-d dashboard.$NM_DOMAIN \
+		-d turn.$NM_DOMAIN \
+		-d turnapi.$NM_DOMAIN
 EOF
 )
+elif [ "$INSTALL_TYPE" = "ee" ]; then
+	CERTBOT_PARAMS=$(cat <<EOF
+	certonly --standalone \
+		--non-interactive --expand --agree-tos \
+		-m $NM_EMAIL \
+		-d api.$NM_DOMAIN \
+		-d broker.$NM_DOMAIN \
+		-d dashboard.$NM_DOMAIN \
+		-d turn.$NM_DOMAIN \
+		-d turnapi.$NM_DOMAIN \
+		-d netmaker-exporter.$NM_DOMAIN \
+		-d grafana.$NM_DOMAIN \
+		-d prometheus.$NM_DOMAIN
+EOF
+)
+fi
 
 # generate an entrypoint for zerossl-certbot
 cat <<EOF >"$SCRIPT_DIR/certbot-entry.sh"


### PR DESCRIPTION
## Describe your changes
nm-certs.sh now requests certificate for EE and CE edition domains accordingly.

## Provide Issue ticket number if applicable/not in title
Issue #2382 

## Provide testing steps
-> Do a normal nm-quick install from the scripts of this branch.
-> Need to comment out line 375 and line 755 on nm-quick.sh file so that it does not replace the nm-certs.sh file from GitHub.
-> Now try to do a fresh install using nm-quick with CE selected. It should only get certificates for CE domains.
-> Again try to do a fresh install using nm-quick with EE selected. It should get certificates for all EE domains.
-> Also, verify upgrading from CE to EE using nm-quick. This should also work and update the certificates with extra EE domains.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
