### PR TITLE
Net 509 515

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -217,7 +217,12 @@ func getExtClientConf(w http.ResponseWriter, r *http.Request) {
 	if network.DefaultKeepalive != 0 {
 		keepalive = "PersistentKeepalive = " + strconv.Itoa(int(network.DefaultKeepalive))
 	}
-	gwendpoint := host.EndpointIP.String() + ":" + strconv.Itoa(host.ListenPort)
+	gwendpoint := ""
+	if host.EndpointIP.To4() == nil {
+		gwendpoint = "[" + host.EndpointIP.String() + "]" + ":" + strconv.Itoa(host.ListenPort)
+	} else {
+		gwendpoint = host.EndpointIP.String() + ":" + strconv.Itoa(host.ListenPort)
+	}
 	newAllowedIPs := network.AddressRange
 	if newAllowedIPs != "" && network.AddressRange6 != "" {
 		newAllowedIPs += ","

--- a/models/network.go
+++ b/models/network.go
@@ -11,10 +11,10 @@ import (
 type Network struct {
 	AddressRange        string                `json:"addressrange" bson:"addressrange" validate:"omitempty,cidrv4"`
 	AddressRange6       string                `json:"addressrange6" bson:"addressrange6" validate:"omitempty,cidrv6"`
-	NetID               string                `json:"netid" bson:"netid" validate:"required,min=1,max=12,netid_valid"`
+	NetID               string                `json:"netid" bson:"netid" validate:"required,min=1,max=32,netid_valid"`
 	NodesLastModified   int64                 `json:"nodeslastmodified" bson:"nodeslastmodified"`
 	NetworkLastModified int64                 `json:"networklastmodified" bson:"networklastmodified"`
-	DefaultInterface    string                `json:"defaultinterface" bson:"defaultinterface" validate:"min=1,max=15"`
+	DefaultInterface    string                `json:"defaultinterface" bson:"defaultinterface" validate:"min=1,max=35"`
 	DefaultListenPort   int32                 `json:"defaultlistenport,omitempty" bson:"defaultlistenport,omitempty" validate:"omitempty,min=1024,max=65535"`
 	NodeLimit           int32                 `json:"nodelimit" bson:"nodelimit"`
 	DefaultPostDown     string                `json:"defaultpostdown" bson:"defaultpostdown"`
@@ -30,7 +30,7 @@ type Network struct {
 
 // SaveData - sensitive fields of a network that should be kept the same
 type SaveData struct { // put sensitive fields here
-	NetID string `json:"netid" bson:"netid" validate:"required,min=1,max=12,netid_valid"`
+	NetID string `json:"netid" bson:"netid" validate:"required,min=1,max=32,netid_valid"`
 }
 
 // Network.SetNodesLastModified - sets nodes last modified on network, depricated
@@ -49,7 +49,7 @@ func (network *Network) SetDefaults() {
 		network.DefaultUDPHolePunch = "no"
 	}
 	if network.DefaultInterface == "" {
-		if len(network.NetID) < 13 {
+		if len(network.NetID) < 33 {
 			network.DefaultInterface = "nm-" + network.NetID
 		} else {
 			network.DefaultInterface = network.NetID


### PR DESCRIPTION
## Describe your changes
Fixed the extclient config files lacking the ipv6 endpoint ip address enclosed in [] when using an ipv6 endpoint
Increased max network name length to 32

## Provide Issue ticket number if applicable/not in title
Issue #2273 
Issue #910 

## Provide testing steps
Network Name ->
1. Try creating a new network with a name of 32 length and make sure the network is created without any error and reflected in the UI properly.
2. When creating a network with a name of length greater than 32, it should show an error message.
3. Verify network functionalities such as delete network working fine.

Extclient ->
1. Change the endpoint ip address of any host to an ipv6 address with static option enabled.
2. Create an ingress gateway with the changed host.
4. Create an extclient using the ingress gateway.
5. Download the extclient config file and verify the endpoint ipv6 address is enclosed inside []
6. Try importing the extclient config file to wireguard applications for windows, mac, android etc.

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
