### PR TITLE
NET-507

### DIFF
--- a/logic/zombie.go
+++ b/logic/zombie.go
@@ -37,7 +37,7 @@ func CheckZombies(newnode *models.Node) {
 			//skip self
 			continue
 		}
-		if node.HostID == newnode.HostID || time.Now().After(node.ExpirationDateTime) {
+		if node.HostID == newnode.HostID {
 			logger.Log(0, "adding ", node.ID.String(), " to zombie list")
 			newZombie <- node.ID
 		}
@@ -97,7 +97,7 @@ func ManageZombies(ctx context.Context, peerUpdate chan *models.Node) {
 						zombies = append(zombies[:i], zombies[i+1:]...)
 						continue
 					}
-					if time.Since(node.LastCheckIn) > time.Minute*ZOMBIE_DELETE_TIME || time.Now().After(node.ExpirationDateTime) {
+					if time.Since(node.LastCheckIn) > time.Minute*ZOMBIE_DELETE_TIME {
 						if err := DeleteNode(&node, true); err != nil {
 							logger.Log(1, "error deleting zombie node", zombies[i].String(), err.Error())
 							continue

--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func runMessageQueue(wg *sync.WaitGroup, ctx context.Context) {
 	go func() {
 		peerUpdate := make(chan *models.Node)
 		go logic.ManageZombies(ctx, peerUpdate)
+		go logic.DeleteExpiredNodes(ctx, peerUpdate)
 		for nodeUpdate := range peerUpdate {
 			if err := mq.NodeUpdate(nodeUpdate); err != nil {
 				logger.Log(0, "failed to send peer update for deleted node: ", nodeUpdate.ID.String(), err.Error())

--- a/models/node.go
+++ b/models/node.go
@@ -341,7 +341,9 @@ func (node *Node) SetLastPeerUpdate() {
 
 // Node.SetExpirationDateTime - sets node expiry time
 func (node *Node) SetExpirationDateTime() {
-	node.ExpirationDateTime = time.Now().Add(TEN_YEARS_IN_SECONDS)
+	if node.ExpirationDateTime.IsZero() {
+		node.ExpirationDateTime = time.Now().Add(TEN_YEARS_IN_SECONDS)
+	}
 }
 
 // Node.SetDefaultName - sets a random name to node


### PR DESCRIPTION
## Describe your changes
An expired node now gets cleaned up every one hour after routine checkup. Expired node time now do not get reset to default on server restart.

## Provide Issue ticket number if applicable/not in title

## Provide testing steps
1. join a client to a network
2. edit the node and change the expiration date to a minute in the future
3. wait approximately 1 hour
4. expired nodes cleanup routine should delete the node
5. Repeat steps 1 and 2
6. Restart the netmaker server
7. Verify if the expiry date and time on the node is same as previously set


## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
