### PR TITLE
NET-517

### DIFF
--- a/compose/docker-compose-emqx.yml
+++ b/compose/docker-compose-emqx.yml
@@ -4,14 +4,23 @@ services:
   mq:
     container_name: mq
     image: emqx/emqx:5.0.9
+    env_file: ./netmaker.env
     restart: unless-stopped
     environment:
-      - EMQX_NAME: "emqx"
+      - EMQX_NAME=emqx
       - EMQX_DASHBOARD__DEFAULT_PASSWORD=${MQ_PASSWORD}
       - EMQX_DASHBOARD__DEFAULT_USERNAME=${MQ_USERNAME}
     ports:
-      - "1883:1883" # MQTT
-      - "8883:8883" # SSL MQTT
-      - "8083:8083" # Websockets
+      - "1883:1883"   # MQTT
+      - "8883:8883"   # SSL MQTT
+      - "8083:8083"   # Websockets
+      - "8084:8084"   # SSL Websockets
       - "18083:18083" # Dashboard/REST_API
-
+    volumes:
+      - emqx_data:/opt/emqx/data
+      - emqx_etc:/opt/emqx/etc
+      - emqx_logs:/opt/emqx/log
+volumes:
+  emqx_data: { } # storage for emqx data
+  emqx_etc: { }  # storage for emqx etc
+  emqx_logs: { } # storage for emqx logs

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       # config-dependant vars
       - STUN_LIST=stun1.netmaker.io:3478,stun2.netmaker.io:3478,stun1.l.google.com:19302,stun2.l.google.com:19302
       # The domain/host IP indicating the mq broker address
-      - BROKER_ENDPOINT=wss://broker.${NM_DOMAIN}
+      - BROKER_ENDPOINT=wss://broker.${NM_DOMAIN} # For EMQX broker use `BROKER_ENDPOINT=wss://broker.${NM_DOMAIN}/mqtt`
+      # For EMQX broker (uncomment the two lines below)
+      #- BROKER_TYPE=emqx
+      #- EMQX_REST_ENDPOINT=http://mq:18083
       # The base domain of netmaker
       - SERVER_NAME=${NM_DOMAIN}
       - SERVER_API_CONN_STRING=api.${NM_DOMAIN}:443

--- a/scripts/netmaker.default.env
+++ b/scripts/netmaker.default.env
@@ -41,7 +41,7 @@ DISPLAY_KEYS="on"
 DATABASE="sqlite"
 # The address of the mq server. If running from docker compose it will be "mq". Otherwise, need to input address.
 # If using "host networking", it will find and detect the IP of the mq container.
-SERVER_BROKER_ENDPOINT="ws://mq:1883"
+SERVER_BROKER_ENDPOINT="ws://mq:1883" # For EMQX websockets use `SERVER_BROKER_ENDPOINT=ws://mq:8083/mqtt`
 # The reachable port of STUN on the server
 STUN_PORT="3478"
 # Logging verbosity level - 1, 2, or 3


### PR DESCRIPTION
## Describe your changes
Fixed emqx docker compose file syntax and added volumes for persistence. Added helper comments for docker-compose.yml and netmaker.env files to enable emqx broker support.

## Provide Issue ticket number if applicable/not in title
Issue #2264 
Issue #2266 

## Provide testing steps
-> Install netmaker server normally with latest nm-quick.sh script.

-> Modify Caddyfile and use the emqx "**reverse_proxy**" line located on MQ section.

-> Modify netmaker.env file and replace the line
`SERVER_BROKER_ENDPOINT=ws://mq:1883`
with
`SERVER_BROKER_ENDPOINT=ws://mq:8083/mqtt`

-> Edit the docker-compose.yml file and change the line
`BROKER_ENDPOINT=wss://broker.${NM_DOMAIN}`
to
`BROKER_ENDPOINT=wss://broker.${NM_DOMAIN}/mqtt`

-> Inside docker-compose.yml file add these lines
```
- BROKER_TYPE=emqx
- EMQX_REST_ENDPOINT=http://mq:18083
```
under the line **BROKER_ENDPOINT=wss://broker.${NM_DOMAIN}/mqtt**

-> Download the latest emqx docker compose file using this command:
`wget https://raw.githubusercontent.com/gravitl/netmaker/{PUT_BRANCH_NAME}/compose/docker-compose-emqx.yml`

-> now execute this command:
`docker-compose down && docker-compose up -d && docker-compose -f docker-compose-emqx.yml up -d`

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [x] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
