### PR TITLE
NET-555

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -398,7 +398,7 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 		if err := mq.PublishPeerUpdate(); err != nil {
 			logger.Log(1, "error setting ext peers on "+nodeid+": "+err.Error())
 		}
-		if err := mq.PublishExtCLientDNS(&extclient); err != nil {
+		if err := mq.PublishExtClientDNS(&extclient); err != nil {
 			logger.Log(1, "error publishing extclient dns", err.Error())
 		}
 	}()

--- a/mq/publishers.go
+++ b/mq/publishers.go
@@ -79,8 +79,10 @@ func PublishDeletedClientPeerUpdate(delClient *models.ExtClient) error {
 	}
 	for _, host := range hosts {
 		host := host
-		if err = PublishSingleHostPeerUpdate(&host, nodes, nil, []models.ExtClient{*delClient}); err != nil {
-			logger.Log(1, "failed to publish peer update to host", host.ID.String(), ": ", err.Error())
+		if host.OS != models.OS_Types.IoT {
+			if err = PublishSingleHostPeerUpdate(&host, nodes, nil, []models.ExtClient{*delClient}); err != nil {
+				logger.Log(1, "failed to publish peer update to host", host.ID.String(), ": ", err.Error())
+			}
 		}
 	}
 	return err
@@ -258,7 +260,7 @@ func PublishReplaceDNS(oldNode, newNode *models.Node, host *models.Host) error {
 }
 
 // PublishExtClientDNS publish dns update for new extclient
-func PublishExtCLientDNS(client *models.ExtClient) error {
+func PublishExtClientDNS(client *models.ExtClient) error {
 	errMsgs := models.DNSError{}
 	dns := models.DNSUpdate{
 		Action:  models.DNSInsert,


### PR DESCRIPTION
* IoT peer updates remove flag is now only triggering on relay deletion. Not triggering on extclients deletion anymore.

* Small typo fix on publish dns update for new extclient function name.

## Describe your changes
Added a check to skip extclient delete peer updates for iot clients.

## Provide Issue ticket number if applicable/not in title

## Provide testing steps
1. Add an IoT client to the network
2. Create a relay and add the IoT client as the relayed node.
3. Create and Delete extclients on the same network.
4. Deletion of the extclients should not trigger the IoT client receiving a peer update also with deletion request.
5. IoT client connection with the relay server should be working fine after step 3

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
