### PR TITLE
feat(NET-591): allow generic DNS entries

### DIFF
--- a/controllers/dns_test.go
+++ b/controllers/dns_test.go
@@ -238,7 +238,7 @@ func TestSetDNS(t *testing.T) {
 		assert.False(t, info.IsDir())
 		content, err := os.ReadFile("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
-		assert.Contains(t, string(content), "linuxhost.skynet")
+		assert.Contains(t, string(content), "linuxhost")
 	})
 	t.Run("EntryExists", func(t *testing.T) {
 		entry := models.DNSEntry{Address: "10.0.0.3", Name: "newhost", Network: "skynet"}
@@ -251,7 +251,7 @@ func TestSetDNS(t *testing.T) {
 		assert.False(t, info.IsDir())
 		content, err := os.ReadFile("./config/dnsconfig/netmaker.hosts")
 		assert.Nil(t, err)
-		assert.Contains(t, string(content), "newhost.skynet")
+		assert.Contains(t, string(content), "newhost")
 	})
 
 }

--- a/logic/dns.go
+++ b/logic/dns.go
@@ -32,7 +32,7 @@ func SetDNS() error {
 			return err
 		}
 		for _, entry := range dns {
-			hostfile.AddHost(entry.Address, entry.Name+"."+entry.Network)
+			hostfile.AddHost(entry.Address, entry.Name)
 		}
 	}
 	if corefilestring == "" {

--- a/mq/publishers.go
+++ b/mq/publishers.go
@@ -315,7 +315,7 @@ func PublishDeleteExtClientDNS(client *models.ExtClient) error {
 func PublishCustomDNS(entry *models.DNSEntry) error {
 	dns := models.DNSUpdate{
 		Action: models.DNSInsert,
-		Name:   entry.Name + "." + entry.Network,
+		Name:   entry.Name,
 		//entry.Address6 is never used
 		Address: entry.Address,
 	}


### PR DESCRIPTION
## Describe your changes
Allow users to create generic DNS entries that are not tied to the network TLD. E.g. "myserver.example.com"
## Provide Issue ticket number if applicable/not in title
NET-591

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
