### PR TITLE
NET-600

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -385,6 +385,11 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 	extclient.RemoteAccessClientID = customExtClient.RemoteAccessClientID
 	extclient.IngressGatewayID = nodeid
 
+	// set extclient dns to ingressdns if extclient dns is not explicitly set
+	if (extclient.DNS == "") && (node.IngressDNS != "") {
+		extclient.DNS = node.IngressDNS
+	}
+
 	extclient.Network = node.Network
 	host, err := logic.GetHost(node.HostID.String())
 	if err != nil {

--- a/logic/extpeers.go
+++ b/logic/extpeers.go
@@ -225,7 +225,7 @@ func UpdateExtClient(old *models.ExtClient, update *models.CustomExtClient) mode
 	if update.PublicKey != "" && old.PublicKey != update.PublicKey {
 		new.PublicKey = update.PublicKey
 	}
-	if update.DNS != "" && update.DNS != old.DNS {
+	if update.DNS != old.DNS {
 		new.DNS = update.DNS
 	}
 	if update.Enabled != old.Enabled {


### PR DESCRIPTION
## Describe your changes
* When individual extclient dns is changed or removed, it reflects on the UI properly and also gets updated on backend.
* Extclients DNS now properly set from ingress dns value provided that the individual extclient DNS are not present. Updated DNS only applies to newly created extclients after an ingress dns update from the netmaker UI. Individual extclients DNS which are set by user will take precedence over ingress gateway dns.

Related to NET-468 and NET-600

## Provide Issue ticket number if applicable/not in title

## Provide testing steps
1. Create an ingress gateway with a DNS address set.
2. Create extclients using this ingress gateway.
3. Open the extclient's details page by clicking on the name.
4. This page should reflect the DNS set on the ingress gateway.
5. Change the ingress gateway dns server to a different one and create another extclient.
6. New ingress gateway dns now should be reflected on the new extclient details page.
7. Any ingress gateway dns changes should properly reflect on newly created extclients unless an extclient have dns server set through its own configuration page.
8. Click on edit button of any extclient.
9. Update client DNS field click on update client.
10. Clear client DNS field and click on update client.
11. Extclient dns should be now clearing or changing properly.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netmaker is awesome.
