### PR TITLE
[NET-633] Set the validation error when err == nil too

### DIFF
--- a/pro/license.go
+++ b/pro/license.go
@@ -51,8 +51,8 @@ func ValidateLicense() (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("%w: %s", errValidation, err.Error())
-			servercfg.ErrLicenseValidation = err
 		}
+		servercfg.ErrLicenseValidation = err
 	}()
 
 	licenseKeyValue := servercfg.GetLicenseKey()


### PR DESCRIPTION
## Describe your changes

The license validation error was not being unset so servers needed to be restarted to work again

## Provide testing steps

- fail validation > get server locked
- pass validation > get server unlocked
