### PR TITLE
docs: fix License section in docs to align with new license model

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,11 @@ After installing Netmaker, check out the [Walkthrough](https://itnext.io/getting
 
 ## License
 
-Netmaker's source code and all artifacts in this repository are freely available. All versions are published under the Server Side Public License (SSPL), version 1, which can be found here: [LICENSE.txt](./LICENSE.txt).
+Netmaker's source code and all artifacts in this repository are freely available.
+All content that resides under the "pro/" directory of this repository, if that
+directory exists, is licensed under the license defined in "pro/LICENSE".
+All third party components incorporated into the Netmaker Software are licensed
+under the original license provided by the owner of the applicable component.
+Content outside of the above mentioned directories or restrictions above is
+available under the "Apache Version 2.0" license as defined below.
+All details for the licenses used can be found here: [LICENSE.md](./LICENSE.md).


### PR DESCRIPTION
* copy the short license description from the License.md to increase visibility
* update link to License.md (was License.txt before)

fixes: #2603