### PR TITLE
Make superadmins not be admins

### DIFF
--- a/logic/auth.go
+++ b/logic/auth.go
@@ -112,6 +112,7 @@ func CreateSuperAdmin(u *models.User) error {
 		return errors.New("superadmin user already exists")
 	}
 	u.IsSuperAdmin = true
+	u.IsAdmin = false
 	return CreateUser(u)
 }
 


### PR DESCRIPTION
A user is either regular/normal, admin or superadmin. Can't be both superadmin and admin at the same time!

This impacts controllers like updating a user role, when we check if a user.IsAdmin we expect it to NOT be also a superadmin.