### PR TITLE
Net 687 : fix license validation failure log (#2675)

### DIFF
--- a/pro/license.go
+++ b/pro/license.go
@@ -237,13 +237,10 @@ func validateLicenseKey(encryptedData []byte, publicKey *[32]byte) ([]byte, erro
 	// at this point the backend returned some undesired state
 
 	// inform failure via logs
-	err = fmt.Errorf("could not validate license with validation backend, got status code %d", validateResponse.StatusCode)
+	body, _ := io.ReadAll(validateResponse.Body)
+	err = fmt.Errorf("could not validate license with validation backend (status={%d}, body={%s})",
+		validateResponse.StatusCode, string(body))
 	slog.Warn(err.Error())
-	body, err := io.ReadAll(validateResponse.Body)
-	if err != nil {
-		slog.Warn(err.Error())
-	}
-	slog.Warn("license-validation backend response: %s", string(body))
 
 	// try to use cache if we had a temporary error
 	if code == http.StatusServiceUnavailable || code == http.StatusGatewayTimeout {


### PR DESCRIPTION
* On license validation fail, parse and store the message of the response

* Return cached response body when necessary

* Have license validation return proper val,err

* Improve logs readability on lic val error

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
