### PR TITLE
nm-quick.sh cleanup and improvements

### DIFF
--- a/scripts/.envrc
+++ b/scripts/.envrc
@@ -1,0 +1,3 @@
+PATH_add bin
+
+source_env_if_exists .env

--- a/scripts/.envrc
+++ b/scripts/.envrc
@@ -1,3 +1,5 @@
 PATH_add bin
 
+set -a
 source_env_if_exists .env
+set +a

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -444,6 +444,7 @@ local_install_setup() { (
 	else
 		cp docker/Caddyfile "$DATA_DIR/Caddyfile"
 	fi
+	cp scripts/.envrc "$DATA_DIR/.envrc"
 	cp scripts/netmaker.default.env "$DATA_DIR/netmaker.default.env"
 	cp docker/mosquitto.conf "$DATA_DIR/mosquitto.conf"
 	cp docker/wait.sh "$DATA_DIR/wait.sh"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+NM_QUICK_VERSION="0.1.2"
+
 if [ "$(id -u)" -ne 0 ]; then
 	echo "This script must be run as root"
 	exit 1
@@ -16,8 +18,6 @@ configure() {
 		# backwards compatibilty for old installs
 		NM_QUICK_DATA_DIR="${SCRIPT_DIR}"
 	fi
-
-NM_QUICK_VERSION="0.1.1"
 
 	DATA_DIR="${NM_QUICK_DATA_DIR}"
 	CONFIG_PATH="$DATA_DIR/$CONFIG_FILENAME"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -231,6 +231,10 @@ install_yq() {
 
 # setup_netclient - adds netclient to docker-compose
 setup_netclient() {
+	if [ -n "$NM_SKIP_CLIENT" ] ; then
+		echo "Skipping setup_netclient() due to NM_SKIP_CLIENT"
+		return
+	fi
 
 	set +e
 	netclient uninstall
@@ -265,6 +269,10 @@ setup_netclient() {
 
 # configure_netclient - configures server's netclient as a default host and an ingress gateway
 configure_netclient() {
+	if [ -n "$NM_SKIP_CLIENT" ] ; then
+		echo "Skipping configure_netclient() due to NM_SKIP_CLIENT"
+		return
+	fi
 
 	NODE_ID=$(sudo cat /etc/netclient/nodes.yml | yq -r .netmaker.commonnode.id)
 	if [ "$NODE_ID" = "" ] || [ "$NODE_ID" = "null" ]; then
@@ -386,6 +394,9 @@ save_config() { (
 	fi
 	if test -n "$NM_SKIP_DEPS"; then
 		save_config_item NM_SKIP_DEPS "$NM_SKIP_DEPS"
+	fi
+	if test -n "$NM_SKIP_CLIENT"; then
+		save_config_item NM_SKIP_CLIENT "$NM_SKIP_CLIENT"
 	fi
 ); }
 
@@ -856,7 +867,7 @@ print_success() {
 
 cleanup() {
 	# remove the existing netclient's instance from the existing network
-	if command -v nmctl >/dev/null 2>&1; then
+	if test -z $NM_SKIP_CLIENT && command -v nmctl &>/dev/null; then
 		local node_id=$(netclient list | jq '.[0].node_id' 2>/dev/null)
 		# trim doublequotes
 		node_id="${node_id//\"/}"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -452,8 +452,12 @@ save_config() { (
 ); }
 
 save_config_item() {
-	local NAME="$1"
-	local VALUE="${2:"${!NAME:-""}"}"
+	local NAME="$1" VALUE
+	if test "$#" -ge 2; then
+		VALUE="$2"
+	else
+		VALUE="${!NAME:-""}"
+	fi
 	#info "$NAME=$VALUE"
 	if test -z "$VALUE"; then
 		# load the default for empty values

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -249,7 +249,7 @@ setup_yq() {
 
 # installs and runs yq on demand
 yq() {
-	if test -z "$HAS_YQ"; then
+	if test -z "${HAS_YQ:-}"; then
 		HAS_YQ=1
 		setup_yq >&2
 	fi
@@ -290,7 +290,7 @@ setup_netclient() {
 }
 
 netclient() {
-	if test -z "$HAS_NETCLIENT"; then
+	if test -z "${HAS_NETCLIENT:-}"; then
 		HAS_NETCLIENT=1
 		wget -qO "${DATA_DIR}/bin/netclient" "https://github.com/gravitl/netclient/releases/download/$LATEST/netclient-linux-$ARCH"
 		chmod +x "${DATA_DIR}/bin/netclient"
@@ -348,7 +348,7 @@ setup_nmctl() {
 
 # nmctl - pulls and configures nmctl on demand
 nmctl() {
-	if test -z "$HAS_NMCTL"; then
+	if test -z "${HAS_NMCTL:-}"; then
 		HAS_NMCTL=1
 		setup_nmctl >&2
 	fi

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -11,10 +11,10 @@ fi
 
 configure() {
 	# set to empty instead of swapping all calls to "${VAR:-""}"
-	: "${NM_SKIP_BUILD:=""}"
-	: "${NM_SKIP_DEPS:=""}"
-	: "${NM_SKIP_CLIENT:=""}"
-	: "${NM_SKIP_CLONE:=""}"
+	: "${NM_SKIP_BUILD:=''}"
+	: "${NM_SKIP_DEPS:=''}"
+	: "${NM_SKIP_CLIENT:=''}"
+	: "${NM_SKIP_CLONE:=''}"
 
 	CONFIG_FILENAME=netmaker.env
 	# location of nm-quick.sh (usually `/root`)
@@ -95,11 +95,11 @@ load_config() {
 read_arguments() {
 	INSTALL_TYPE="ce"
 
-	unset BUILD_TYPE
-	unset BUILD_TAG
-	unset IMAGE_TAG
-	unset AUTO_BUILD
-	unset NETMAKER_BASE_DOMAIN
+	BUILD_TYPE=''
+	BUILD_TAG=''
+	IMAGE_TAG=''
+	AUTO_BUILD=''
+	NETMAKER_BASE_DOMAIN=''
 
 	while getopts evabC:d:t:m: flag; do
 		case "${flag}" in
@@ -654,7 +654,7 @@ set_install_vars() {
 	if test -z "$MASTER_KEY"; then
 		MASTER_KEY="$(make_password 30)"
 	fi
-	DOMAIN_TYPE=""
+	DOMAIN_TYPE=''
 	info "-----------------------------------------------------"
 	info "Would you like to use your own domain for netmaker, or an auto-generated domain?"
 	info "To use your own domain, add a Wildcard DNS record (e.x: *.netmaker.example.com) pointing to $SERVER_HOST"
@@ -716,21 +716,20 @@ set_install_vars() {
 		info "    3. Retrieve License and Tenant ID"
 		info "    4. note email address"
 		info "-----------------------------------------------------"
-		unset LICENSE_KEY
+		LICENSE_KEY=''
 		while [ -z "$LICENSE_KEY" ]; do
 			read -r -p "License Key: " LICENSE_KEY
 		done
-		unset TENANT_ID
+		TENANT_ID=''
 		while [ -z "${TENANT_ID}" ]; do
 			read -r -p "Tenant ID: " TENANT_ID
 		done
 	fi
 
-	unset GET_EMAIL
-	unset RAND_EMAIL
+	GET_EMAIL=''
 	RAND_EMAIL="$(info $RANDOM | md5sum | head -c 16)@email.com"
 	# suggest the prev email or a random one
-	EMAIL_SUGGESTED=${NM_EMAIL:-$RAND_EMAIL}
+	EMAIL_SUGGESTED="${NM_EMAIL:-$RAND_EMAIL}"
 	if [ -z $AUTO_BUILD ]; then
 		read -r -p "Email Address for Domain Registration (click 'enter' to use $EMAIL_SUGGESTED): " GET_EMAIL
 	fi
@@ -747,9 +746,10 @@ set_install_vars() {
 
 	wait_seconds 1
 
-	unset GET_MQ_USERNAME
-	unset GET_MQ_PASSWORD
-	unset CONFIRM_MQ_PASSWORD
+	GET_MQ_USERNAME=''
+	GET_MQ_PASSWORD=''
+	CONFIRM_MQ_PASSWORD=''
+
 	info "Enter Credentials For MQ..."
 	if [ -z $AUTO_BUILD ]; then
 		read -r -p "MQ Username (click 'enter' to use 'netmaker'): " GET_MQ_USERNAME

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eEuo pipefail
 
 NM_QUICK_VERSION="0.1.2"
 
@@ -251,9 +252,7 @@ setup_netclient() {
 		return
 	fi
 
-	set +e
-	netclient uninstall
-	set -e
+	netclient uninstall || :
 
 	netclient install
 
@@ -309,11 +308,9 @@ configure_netclient() {
 	echo "making host a default"
 	echo "Host ID: $HOST_ID"
 	# set as a default host
-	set +e
-	nmctl host update $HOST_ID --default
+	nmctl host update $HOST_ID --default || :
 	sleep 5
-	nmctl node create_ingress netmaker $NODE_ID
-	set -e
+	nmctl node create_ingress netmaker $NODE_ID || :
 }
 
 setup_nmctl() {
@@ -588,7 +585,6 @@ install_dependencies() {
 	echo "dependency check complete"
 	echo "-----------------------------------------------------"
 }
-set -e
 
 # set_install_vars - sets the variables that will be used throughout installation
 set_install_vars() {
@@ -926,32 +922,22 @@ print_logo
 # 2. prepare configuration & setup the build instruction
 configure "$@"
 
-set +e
-
 # 3. install necessary packages
-install_dependencies
-
-set -e
+install_dependencies || :
 
 # 4. get user input for variables
 set_install_vars
 
-set +e
-cleanup
-set -e
+cleanup || :
 
 # 5. get and set config files, startup docker-compose
 install_netmaker
-
-set +e
 
 # 6. make sure Caddy certs are working
 test_connection
 
 # 7. create a default mesh network for netmaker
 setup_mesh
-
-set -e
 
 # 8. add netclient to docker-compose and start it up
 setup_netclient

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -463,7 +463,7 @@ save_config_item() {
 		# load the default for empty values
 		VALUE="$(awk -F'=' "/^$NAME/ { print \$2}" "$DATA_DIR/netmaker.default.env")"
 		# trim quotes for docker
-		VALUE="$(info "$VALUE" | sed -E "s|^(['\"])(.*)\1$|\2|g")"
+		VALUE="$(echo "$VALUE" | sed -E "s|^(['\"])(.*)\1$|\2|g")"
 		#info "Default for $NAME=$VALUE"
 	fi
 	# escape | in the value
@@ -475,7 +475,7 @@ save_config_item() {
 	if grep -q "^$NAME=" "$CONFIG_PATH"; then
 		sed -i "s|$NAME=.*|$NAME=$VALUE|" "$CONFIG_PATH"
 	else
-		info "$NAME=$VALUE" >>"$CONFIG_PATH"
+		echo "$NAME=$VALUE" >>"$CONFIG_PATH"
 	fi
 }
 
@@ -652,7 +652,7 @@ set_install_vars() {
 		IP_ADDR="$(curl -s ifconfig.me)"
 	fi
 	if [ "$NETMAKER_BASE_DOMAIN" = "" ]; then
-		NETMAKER_BASE_DOMAIN=nm.$(info "$IP_ADDR" | tr . -).nip.io
+		NETMAKER_BASE_DOMAIN=nm.$(echo "$IP_ADDR" | tr . -).nip.io
 	fi
 	SERVER_HOST="$IP_ADDR"
 	if test -z "$MASTER_KEY"; then
@@ -731,7 +731,7 @@ set_install_vars() {
 	fi
 
 	GET_EMAIL=''
-	RAND_EMAIL="$(info $RANDOM | md5sum | head -c 16)@email.com"
+	RAND_EMAIL="$(echo $RANDOM | md5sum | head -c 16)@email.com"
 	# suggest the prev email or a random one
 	EMAIL_SUGGESTED="${NM_EMAIL:-$RAND_EMAIL}"
 	if [ -z $AUTO_BUILD ]; then

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -51,20 +51,21 @@ usage() {
 	cat <<EOF
 nm-quick.sh v${NM_QUICK_VERSION}
 usage: ./nm-quick.sh [-e] [-b buildtype] [-t tag] [-a auto] [-d domain]
-	-e      if specified, will install netmaker pro
-	-b      type of build; options:
-					\"version\" - will install a specific version of Netmaker using remote git and dockerhub
-					\"local\": - will install by cloning repo and building images from git
-					\"branch\": - will install a specific branch using remote git and dockerhub
-	-t      tag of build; if buildtype=version, tag=version. If builtype=branch or builtype=local, tag=branch
-	-a      auto-build; skip prompts and use defaults, if none provided
-	-d      domain; if specified, will use this domain instead of auto-generating one
-	-m      email; if specified, will use this email for certificate requests instead of auto-generating one
+  -e      if specified, will install netmaker pro
+  -b      type of build; options:
+          \"version\" - will install a specific version of Netmaker using remote git and dockerhub
+          \"local\": - will install by cloning repo and building images from git
+          \"branch\": - will install a specific branch using remote git and dockerhub
+  -t      tag of build; if buildtype=version, tag=version. If builtype=branch or builtype=local, tag=branch
+  -a      auto-build; skip prompts and use defaults, if none provided
+  -d      domain; if specified, will use this domain instead of auto-generating one
+  -m      email; if specified, will use this email for certificate requests instead of auto-generating one
+  -C      don't configure Netclient
 examples:
-					nm-quick.sh -e -b version -t $LATEST
-					nm-quick.sh -e -b local -t feature_v0.17.2_newfeature
-					nm-quick.sh -e -b branch -t develop
-					nm-quick.sh -e -b version -t $LATEST -a -d example.com
+          nm-quick.sh -e -b version -t $LATEST
+          nm-quick.sh -e -b local -t feature_v0.17.2_newfeature
+          nm-quick.sh -e -b branch -t develop
+          nm-quick.sh -e -b version -t $LATEST -a -d example.com
 EOF
 	exit 1
 }
@@ -88,7 +89,7 @@ read_arguments() {
 	unset AUTO_BUILD
 	unset NETMAKER_BASE_DOMAIN
 
-	while getopts evab:d:t:m: flag; do
+	while getopts evabC:d:t:m: flag; do
 		case "${flag}" in
 		e)
 			INSTALL_TYPE="pro"
@@ -118,6 +119,9 @@ read_arguments() {
 			;;
 		m)
 			NM_EMAIL="${OPTARG}"
+			;;
+		C)
+			NM_SKIP_CLIENT=1
 			;;
 		*)
 			echo "error: unknown flag ${flag}"
@@ -251,7 +255,7 @@ setup_netclient() {
 
 	netclient install
 
-  local token
+	local token
 	token="$(get_enrollment_key)"
 	echo "Register token: $token"
 	netclient register -t $token

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$(id -u)" -ne 0 ]; then
+	echo "This script must be run as root"
+	exit 1
+fi
+
 CONFIG_FILENAME=netmaker.env
 # location of nm-quick.sh (usually `/root`)
 SCRIPT_DIR="${BASH_SOURCE[0]%/*}"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -25,13 +25,6 @@ mkdir -p "${DATA_DIR}/bin"
 pushd "${DATA_DIR}"
 export PATH="${DATA_DIR}/bin:${PATH}"
 
-LATEST=$(curl -s https://api.github.com/repos/gravitl/netmaker/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d [:space:],\")
-
-if [ $(id -u) -ne 0 ]; then
-	echo "This script must be run as root"
-	exit 1
-fi
-
 unset INSTALL_TYPE
 unset BUILD_TYPE
 unset BUILD_TAG
@@ -110,8 +103,17 @@ print_logo() {
 EOF
 }
 
+get_latest_version() {
+	wget -qO- https://api.github.com/repos/gravitl/netmaker/releases/latest | if command -v jq &>/dev/null; then
+		jq -r .tag_name
+	else
+		grep "tag_name" | cut -d : -f 2,3 | tr -d '[:space:],"'
+	fi
+}
+
 # set_buildinfo - sets the information based on script input for how the installation should be run
 set_buildinfo() {
+	LATEST="$(get_latest_version)"
 
 	if [ -z "$BUILD_TYPE" ]; then
 		BUILD_TYPE="version"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -48,21 +48,24 @@ NM_QUICK_VERSION="0.1.1"
 
 # usage - displays usage instructions
 usage() {
-	echo "nm-quick.sh v$NM_QUICK_VERSION"
-	echo "usage: ./nm-quick.sh [-e] [-b buildtype] [-t tag] [-a auto] [-d domain]"
-	echo "  -e      if specified, will install netmaker pro"
-	echo "  -b      type of build; options:"
-	echo "          \"version\" - will install a specific version of Netmaker using remote git and dockerhub"
-	echo "          \"local\": - will install by cloning repo and building images from git"
-	echo "          \"branch\": - will install a specific branch using remote git and dockerhub"
-	echo "  -t      tag of build; if buildtype=version, tag=version. If builtype=branch or builtype=local, tag=branch"
-	echo "  -a      auto-build; skip prompts and use defaults, if none provided"
-	echo "  -d      domain; if specified, will use this domain instead of auto-generating one"
-	echo "examples:"
-	echo "          nm-quick.sh -e -b version -t $LATEST"
-	echo "          nm-quick.sh -e -b local -t feature_v0.17.2_newfeature"
-	echo "          nm-quick.sh -e -b branch -t develop"
-	echo "          nm-quick.sh -e -b version -t $LATEST -a -d example.com"
+	cat <<EOF
+nm-quick.sh v${NM_QUICK_VERSION}
+usage: ./nm-quick.sh [-e] [-b buildtype] [-t tag] [-a auto] [-d domain]
+	-e      if specified, will install netmaker pro
+	-b      type of build; options:
+					\"version\" - will install a specific version of Netmaker using remote git and dockerhub
+					\"local\": - will install by cloning repo and building images from git
+					\"branch\": - will install a specific branch using remote git and dockerhub
+	-t      tag of build; if buildtype=version, tag=version. If builtype=branch or builtype=local, tag=branch
+	-a      auto-build; skip prompts and use defaults, if none provided
+	-d      domain; if specified, will use this domain instead of auto-generating one
+	-m      email; if specified, will use this email for certificate requests instead of auto-generating one
+examples:
+					nm-quick.sh -e -b version -t $LATEST
+					nm-quick.sh -e -b local -t feature_v0.17.2_newfeature
+					nm-quick.sh -e -b branch -t develop
+					nm-quick.sh -e -b version -t $LATEST -a -d example.com
+EOF
 	exit 1
 }
 
@@ -85,7 +88,7 @@ read_arguments() {
 	unset AUTO_BUILD
 	unset NETMAKER_BASE_DOMAIN
 
-	while getopts evab:d:t: flag; do
+	while getopts evab:d:t:m: flag; do
 		case "${flag}" in
 		e)
 			INSTALL_TYPE="pro"
@@ -108,10 +111,13 @@ read_arguments() {
 			fi
 			;;
 		t)
-			BUILD_TAG=${OPTARG}
+			BUILD_TAG="${OPTARG}"
 			;;
 		d)
-			NETMAKER_BASE_DOMAIN=${OPTARG}
+			NETMAKER_BASE_DOMAIN="${OPTARG}"
+			;;
+		m)
+			NM_EMAIL="${OPTARG}"
 			;;
 		*)
 			echo "error: unknown flag ${flag}"

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -331,7 +331,7 @@ save_config_item() { (
 	#echo "$NAME=$VALUE"
 	if test -z "$VALUE"; then
 		# load the default for empty values
-		VALUE=$(awk -F'=' "/^$NAME/ { print \$2}"  "$SCRIPT_DIR/netmaker.default.env")
+		VALUE=$(awk -F'=' "/^$NAME/ { print \$2}" "$SCRIPT_DIR/netmaker.default.env")
 		# trim quotes for docker
 		VALUE=$(echo "$VALUE" | sed -E "s|^(['\"])(.*)\1$|\2|g")
 		#echo "Default for $NAME=$VALUE"
@@ -428,14 +428,14 @@ install_dependencies() {
 	fi
 	# TODO add other supported architectures
 	ARCH=$(uname -m)
-    if [ "$ARCH" = "x86_64" ]; then
-    	ARCH=amd64
-    elif [ "$ARCH" = "aarch64" ]; then
-    	ARCH=arm64
-    else
-    	echo "Unsupported architechure"
-    	# exit 1
-    fi
+	if [ "$ARCH" = "x86_64" ]; then
+		ARCH=amd64
+	elif [ "$ARCH" = "aarch64" ]; then
+		ARCH=arm64
+	else
+		echo "Unsupported architechure"
+		# exit 1
+	fi
 	set -- $dependencies
 
 	${update_cmd}


### PR DESCRIPTION
## Describe your changes

I am trying to run `nm-quick.sh` on a NixOS system and thought I would share the non-NixOS specific changes upstream along with good deal of cleanups and unifications.

Commit history should be describing specific changes sufficiently.

This is based off of `v0.21.2`

## Provide Issue ticket number if applicable/not in title

N/A

## Provide testing steps

Tested by building and using it with my code at https://github.com/nazarewk-iac/nix-configs/commit/6ff0bd45f72971223a4c7557be37889d6b3d11ad

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
