### PR TITLE
fix(NET-1175): use default trial end date

### DIFF
--- a/logic/serverconf.go
+++ b/logic/serverconf.go
@@ -21,9 +21,11 @@ var (
 	EgressesLimit = 1000000000
 	// FreeTier - specifies if free tier
 	FreeTier = false
+	// DefaultTrialEndDate - is a placeholder date for not applicable trial end dates
+	DefaultTrialEndDate, _ = time.Parse("2006-Jan-02", "2021-Apr-01")
 
 	GetTrialEndDate = func() (time.Time, error) {
-		return time.Time{}, nil
+		return DefaultTrialEndDate, nil
 	}
 )
 

--- a/pro/trial.go
+++ b/pro/trial.go
@@ -124,37 +124,37 @@ func TrialLicenseHook() error {
 func getTrialEndDate() (time.Time, error) {
 	record, err := database.FetchRecord(trial_table_name, trial_data_key)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	var trialInfo TrialInfo
 	err = json.Unmarshal([]byte(record), &trialInfo)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	tel, err := logic.FetchTelemetryRecord()
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	telePrivKey, err := ncutils.ConvertBytesToKey(tel.TrafficKeyPriv)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	trialPubKey, err := ncutils.ConvertBytesToKey(trialInfo.PubKey)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	// decrypt secret
 	secretDecrypt, err := ncutils.BoxDecrypt(trialInfo.Secret, trialPubKey, telePrivKey)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	trialDates := TrialDates{}
 	err = json.Unmarshal(secretDecrypt, &trialDates)
 	if err != nil {
-		return time.Time{}, err
+		return logic.DefaultTrialEndDate, err
 	}
 	if trialDates.TrialEndsAt.IsZero() {
-		return time.Time{}, errors.New("invalid date")
+		return logic.DefaultTrialEndDate, errors.New("invalid date")
 	}
 	return trialDates.TrialEndsAt, nil
 


### PR DESCRIPTION
this "more recent" arbitrary date is needed for hubspot to consume exported data without throwing out of date range exeptions

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
