### PR TITLE
fix(NET-1280): remove RAG metadata length restriction

### DIFF
--- a/controllers/node.go
+++ b/controllers/node.go
@@ -631,10 +631,6 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, "badrequest"))
 		return
 	}
-	if len(newData.Metadata) > 255 {
-		logic.ReturnErrorResponse(w, r, logic.FormatError(fmt.Errorf("metadata cannot be longer than 255 characters"), "badrequest"))
-		return
-	}
 	if !servercfg.IsPro {
 		newData.AdditionalRagIps = []string{}
 	}

--- a/models/api_node.go
+++ b/models/api_node.go
@@ -36,7 +36,7 @@ type ApiNode struct {
 	Server                  string   `json:"server"`
 	Connected               bool     `json:"connected"`
 	PendingDelete           bool     `json:"pendingdelete"`
-	Metadata                string   `json:"metadata" validate:"max=256"`
+	Metadata                string   `json:"metadata"`
 	// == PRO ==
 	DefaultACL        string              `json:"defaultacl,omitempty" validate:"checkyesornoorunset"`
 	IsFailOver        bool                `json:"is_fail_over"`


### PR DESCRIPTION
## Describe your changes
this pr removes RAG metadata length restriction

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
