### PR TITLE
Simplify and unify apk usage in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.21.2
 # add a c lib
 # set the working directory
 WORKDIR /root/
-RUN apk update && apk upgrade
+RUN apk upgrade --no-cache
 RUN apk add --no-cache sqlite
 RUN mkdir -p /etc/netclient/config
 COPY --from=builder /app/netmaker .

--- a/Dockerfile-quick
+++ b/Dockerfile-quick
@@ -6,7 +6,7 @@ COPY ./netmaker /root/netmaker
 ENV GO111MODULE=auto
 
 # add a c lib
-RUN apk add gcompat iptables wireguard-tools
+RUN apk add --no-cache gcompat iptables wireguard-tools
 # set the working directory
 WORKDIR /root/
 RUN mkdir -p /etc/netclient/config

--- a/docker/Dockerfile-go-builder
+++ b/docker/Dockerfile-go-builder
@@ -1,6 +1,6 @@
 FROM golang:1.23.0-alpine3.20
 ARG version 
-RUN apk add build-base
+RUN apk add --no-cache build-base
 WORKDIR /app
 COPY go.* ./ 
 RUN go mod download

--- a/docker/Dockerfile-netclient-multiarch
+++ b/docker/Dockerfile-netclient-multiarch
@@ -13,7 +13,7 @@ FROM alpine:3.16.2
 
 WORKDIR /root/
 
-RUN apk add --no-cache --update bash libmnl gcompat iptables openresolv iproute2 wireguard-tools 
+RUN apk add --no-cache bash libmnl gcompat iptables openresolv iproute2 wireguard-tools 
 COPY --from=builder /app/netclient-app ./netclient
 COPY --from=builder /app/scripts/netclient.sh .
 RUN chmod 0755 netclient && chmod 0755 netclient.sh

--- a/docker/Dockerfile-netclient-multiarch-userspace
+++ b/docker/Dockerfile-netclient-multiarch-userspace
@@ -10,7 +10,7 @@ RUN GOOS=linux CGO_ENABLED=0 /usr/local/go/bin/go build -ldflags="-w -s" -o netc
 
 WORKDIR /root/
 
-RUN apk add --update git build-base libmnl-dev iptables
+RUN apk add --no-cache git build-base libmnl-dev iptables
 
 RUN git clone https://git.zx2c4.com/wireguard-go && \
     cd wireguard-go && \
@@ -28,7 +28,7 @@ FROM alpine:3.16.2
 
 WORKDIR /root/
 
-RUN apk add --no-cache --update bash libmnl gcompat iptables openresolv iproute2
+RUN apk add --no-cache bash libmnl gcompat iptables openresolv iproute2
 COPY --from=builder /usr/bin/wireguard-go /usr/bin/wg* /usr/bin/
 COPY --from=builder /app/netclient-app ./netclient
 COPY --from=builder /app/scripts/netclient.sh .


### PR DESCRIPTION
Replace `apk update` and `--update` flags with `--no-cache` across Dockerfiles to improve consistency and eliminate unnecessary cache files.

This change reduces image size and ensures up-to-date package indices without leaving temporary data. It also aligns with best practices recommended for Alpine-based Docker images.

## Describe your changes

Simplified and unified apk usage in all Dockerfiles by replacing
`apk update` and `--update` with `--no-cache` to avoid unnecessary
cache files and ensure consistency.

## Provide Issue ticket number if applicable/not in title

N/A

## Provide testing steps

- Build Docker images and verify that the images no longer contain `/var/cache/apk` temp files

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netmaker is awesome.
