### PR TITLE
NM-325: QR Code Size Limits

### DIFF
--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -395,7 +395,7 @@ Endpoint = %s
 	)
 
 	if params["type"] == "qr" {
-		bytes, err := qrcode.Encode(config, qrcode.Medium, 220)
+		bytes, err := qrcode.Encode(config, qrcode.Medium, -5)
 		if err != nil {
 			logger.Log(1, r.Header.Get("user"), "failed to encode qr code: ", err.Error())
 			logic.ReturnErrorResponse(w, r, logic.FormatError(err, "internal"))


### PR DESCRIPTION
## Describe your changes

Size restriction causes the qr code generation to fail for larger extclient configs (ones with lots of allowed ips). Keeping it variable ensures all qr codes generate successfully.

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
