### PR TITLE
fix: trim forwarded IP headers before parsing

### DIFF
--- a/controllers/ipservice.go
+++ b/controllers/ipservice.go
@@ -43,7 +43,7 @@ func getPublicIP(w http.ResponseWriter, r *http.Request) {
 
 func parseIP(r *http.Request) (string, error) {
 	// Get Public IP from header
-	ip := r.Header.Get("X-REAL-IP")
+	ip := strings.TrimSpace(r.Header.Get("X-REAL-IP"))
 	ipnet := net.ParseIP(ip)
 	if ipnet != nil && !ncutils.IpIsPrivate(ipnet) {
 		return ip, nil
@@ -53,6 +53,7 @@ func parseIP(r *http.Request) (string, error) {
 	forwardips := r.Header.Get("X-FORWARDED-FOR")
 	iplist := strings.Split(forwardips, ",")
 	for _, ip := range iplist {
+		ip = strings.TrimSpace(ip)
 		ipnet := net.ParseIP(ip)
 		if ipnet != nil && !ncutils.IpIsPrivate(ipnet) {
 			return ip, nil

--- a/controllers/ipservice_test.go
+++ b/controllers/ipservice_test.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseIPTrimsForwardedForEntries(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("X-FORWARDED-FOR", "10.0.0.1, 8.8.8.8")
+	req.RemoteAddr = "10.0.0.2:1234"
+
+	ip, err := parseIP(req)
+	if err != nil {
+		t.Fatalf("parseIP() returned error: %v", err)
+	}
+	if ip != "8.8.8.8" {
+		t.Fatalf("parseIP() = %q, want %q", ip, "8.8.8.8")
+	}
+}


### PR DESCRIPTION
Fixes a small edge in `/api/getip`.

`X-Forwarded-For` is comma separated, and proxies often leave a space after the comma. Before this, `10.0.0.1, 8.8.8.8` made `net.ParseIP(" 8.8.8.8")` nope out, so the handler fell through to `RemoteAddr` and could return `ip is a private address`.

Repro:
1. call `parseIP`/`getip` with `X-FORWARDED-FOR: 10.0.0.1, 8.8.8.8`
2. set `RemoteAddr` to a private IP
3. current code errors instead of picking `8.8.8.8`

This trims `X-REAL-IP` and each forwarded entry before parsing. Tiny fix, no behavior change for already clean headers.

Tests:
`go test ./controllers -count=1`
`go test ./functions ./models ./validation ./netclient/ncutils ./logic -run Test -count=1`