### PR TITLE
ci: bind branch names to env before writing them to GITHUB_ENV

### DIFF
--- a/.github/workflows/branchtest.yml
+++ b/.github/workflows/branchtest.yml
@@ -32,12 +32,15 @@ jobs:
     steps:
       - name: Determine branches
         id: determine_branches
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "NETMAKER_BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
-            echo "NETCLIENT_BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+            echo "NETMAKER_BRANCH=$INPUT_BRANCH" >> $GITHUB_ENV
+            echo "NETCLIENT_BRANCH=$INPUT_BRANCH" >> $GITHUB_ENV
           else
-            echo "NETMAKER_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+            echo "NETMAKER_BRANCH=$HEAD_REF" >> $GITHUB_ENV
             echo "NETCLIENT_BRANCH=develop" >> $GITHUB_ENV
           fi
       - name: Checkout netclient repository


### PR DESCRIPTION
Hi, and thanks for Netmaker.

In `.github/workflows/branchtest.yml`, the "Determine branches" step writes branch names into the environment file by interpolation:

```yaml
run: |
  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
    echo "NETMAKER_BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
    echo "NETCLIENT_BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
  else
    echo "NETMAKER_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
```

Actions expands `${{ ... }}` into the script text before bash runs, so both values become part of the command. Git allows `$`, `(`, `)` and backticks in branch names, the dispatch input is free text, and `$(...)` runs inside double quotes.

Because these write to `$GITHUB_ENV` there is a second effect: a value containing a newline can define extra environment variables for every later step in the job, not only the two intended ones.

The change binds both to step-level environment variables first:

```yaml
env:
  INPUT_BRANCH: ${{ github.event.inputs.branch }}
  HEAD_REF: ${{ github.head_ref }}
run: |
  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
    echo "NETMAKER_BRANCH=$INPUT_BRANCH" >> $GITHUB_ENV
    ...
    echo "NETMAKER_BRANCH=$HEAD_REF" >> $GITHUB_ENV
```

`NETMAKER_BRANCH` and `NETCLIENT_BRANCH` end up with the same values, and the `NETCLIENT_BRANCH=develop` default is untouched. I left `github.event_name` interpolated on purpose — it is a fixed GitHub-controlled string.

On scope: `pull_request` gives a fork a read-only token and no secrets, and the dispatch path needs someone who can already run workflows. Hardening rather than a live exploit.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
