### PR TITLE
NM-362:  correlate Wazuh agents with additional fallback methods

### DIFF
--- a/pro/integration/edr/registry.go
+++ b/pro/integration/edr/registry.go
@@ -16,6 +16,10 @@ type ManagedEndpoint struct {
 	SerialNumber     string
 	Hostname         string
 	EntraDeviceID    string
+	// EndpointIP is the IP reported by the EDR agent (Wazuh agent.ip).
+	EndpointIP string
+	// NetmakerHostID is populated when an EDR agent carries a netmaker.host_id label.
+	NetmakerHostID string
 
 	AgentInstalled bool
 	AgentHealthy   bool

--- a/pro/integration/edr/sync.go
+++ b/pro/integration/edr/sync.go
@@ -200,6 +200,9 @@ func serialMatch(hostSerial, deviceSerial string) bool {
 }
 
 func matchWazuhHostToEndpoint(h schema.Host, ep ManagedEndpoint) (matchedBy string, ok bool) {
+	if serialMatch(h.SerialNumber, ep.SerialNumber) {
+		return schema.EDRMatchSerialNumber, true
+	}
 	if h.ID != uuid.Nil && strings.EqualFold(h.ID.String(), strings.TrimSpace(ep.Hostname)) {
 		return schema.EDRMatchHostID, true
 	}

--- a/pro/integration/edr/sync.go
+++ b/pro/integration/edr/sync.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitl/netmaker/db"
 	"github.com/gravitl/netmaker/logger"
 	"github.com/gravitl/netmaker/schema"
@@ -154,6 +156,8 @@ func runSyncLocked(ctx context.Context, intg *schema.Integration, force bool) er
 
 func hostEligibleForEDR(providerID string, h schema.Host) bool {
 	switch providerID {
+	case ProviderWazuh:
+		return h.ID != uuid.Nil
 	case ProviderDefender:
 		return strings.TrimSpace(h.EntraDeviceID) != "" || strings.TrimSpace(h.SerialNumber) != ""
 	default:
@@ -163,6 +167,8 @@ func hostEligibleForEDR(providerID string, h schema.Host) bool {
 
 func MatchHostToEndpoint(providerID string, h schema.Host, ep ManagedEndpoint) (matchedBy string, ok bool) {
 	switch providerID {
+	case ProviderWazuh:
+		return matchWazuhHostToEndpoint(h, ep)
 	case ProviderDefender:
 		if entra := strings.TrimSpace(h.EntraDeviceID); entra != "" {
 			if deviceEntra := strings.TrimSpace(ep.EntraDeviceID); deviceEntra != "" &&
@@ -191,6 +197,52 @@ func serialMatch(hostSerial, deviceSerial string) bool {
 	hostSerial = strings.TrimSpace(hostSerial)
 	deviceSerial = strings.TrimSpace(deviceSerial)
 	return hostSerial != "" && deviceSerial != "" && strings.EqualFold(hostSerial, deviceSerial)
+}
+
+func matchWazuhHostToEndpoint(h schema.Host, ep ManagedEndpoint) (matchedBy string, ok bool) {
+	if h.ID != uuid.Nil && strings.EqualFold(h.ID.String(), strings.TrimSpace(ep.Hostname)) {
+		return schema.EDRMatchHostID, true
+	}
+	if labelID := strings.TrimSpace(ep.NetmakerHostID); labelID != "" &&
+		h.ID != uuid.Nil && strings.EqualFold(labelID, h.ID.String()) {
+		return schema.EDRMatchHostID, true
+	}
+	if strings.EqualFold(strings.TrimSpace(h.Name), strings.TrimSpace(ep.Hostname)) &&
+		HostEndpointIPMatches(h, ep.EndpointIP) {
+		return schema.EDRMatchHostname, true
+	}
+	return "", false
+}
+
+// WazuhAgentIPUsable reports whether a Wazuh agent-reported IP is suitable for correlation.
+func WazuhAgentIPUsable(ip string) bool {
+	ip = strings.TrimSpace(strings.ToLower(ip))
+	if ip == "" || ip == "any" {
+		return false
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return !parsed.IsLoopback()
+}
+
+// HostEndpointIPMatches reports whether a Wazuh agent IP equals the host WireGuard endpoint.
+func HostEndpointIPMatches(h schema.Host, agentIP string) bool {
+	if !WazuhAgentIPUsable(agentIP) {
+		return false
+	}
+	parsed := net.ParseIP(strings.TrimSpace(agentIP))
+	if parsed == nil {
+		return false
+	}
+	if len(h.EndpointIP) > 0 && h.EndpointIP.Equal(parsed) {
+		return true
+	}
+	if len(h.EndpointIPv6) > 0 && h.EndpointIPv6.Equal(parsed) {
+		return true
+	}
+	return false
 }
 
 func normalizeGUID(id string) string {

--- a/pro/integration/edr/sync_test.go
+++ b/pro/integration/edr/sync_test.go
@@ -1,6 +1,7 @@
 package edr
 
 import (
+	"net"
 	"testing"
 
 	"github.com/google/uuid"
@@ -84,5 +85,89 @@ func TestHostEligibleForEDR(t *testing.T) {
 	}
 	if !hostEligibleForEDR(ProviderCrowdStrike, schema.Host{SerialNumber: "SN1"}) {
 		t.Fatal("crowdstrike eligible with serial_number")
+	}
+}
+
+func TestHostEligibleForEDR_Wazuh(t *testing.T) {
+	if hostEligibleForEDR(ProviderWazuh, schema.Host{}) {
+		t.Fatal("wazuh requires registered host id")
+	}
+	if !hostEligibleForEDR(ProviderWazuh, schema.Host{ID: uuid.New()}) {
+		t.Fatal("wazuh eligible with host id")
+	}
+}
+
+func TestMatchHostToEndpoint_WazuhHostIDByName(t *testing.T) {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	host := schema.Host{ID: id, Name: "web-01"}
+	ep := ManagedEndpoint{Hostname: id.String(), EndpointIP: "10.0.0.99"}
+	matchedBy, ok := MatchHostToEndpoint(ProviderWazuh, host, ep)
+	if !ok || matchedBy != schema.EDRMatchHostID {
+		t.Fatalf("expected host_id match, got %q ok=%v", matchedBy, ok)
+	}
+}
+
+func TestMatchHostToEndpoint_WazuhHostIDByLabel(t *testing.T) {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	host := schema.Host{ID: id, Name: "web-01"}
+	ep := ManagedEndpoint{
+		Hostname:       "web-01",
+		EndpointIP:     "10.0.0.1",
+		NetmakerHostID: id.String(),
+	}
+	matchedBy, ok := MatchHostToEndpoint(ProviderWazuh, host, ep)
+	if !ok || matchedBy != schema.EDRMatchHostID {
+		t.Fatalf("expected host_id label match, got %q ok=%v", matchedBy, ok)
+	}
+}
+
+func TestMatchHostToEndpoint_WazuhHostnameOnlyRejected(t *testing.T) {
+	host := schema.Host{ID: uuid.New(), Name: "web-01", EndpointIP: net.ParseIP("10.0.0.5")}
+	ep := ManagedEndpoint{Hostname: "web-01", EndpointIP: "10.0.0.9"}
+	if _, ok := MatchHostToEndpoint(ProviderWazuh, host, ep); ok {
+		t.Fatal("expected no match when hostname matches but endpoint ip differs")
+	}
+}
+
+func TestMatchHostToEndpoint_WazuhHostnameAndEndpoint(t *testing.T) {
+	host := schema.Host{
+		ID:         uuid.New(),
+		Name:       "web-01",
+		EndpointIP: net.ParseIP("10.0.0.5"),
+	}
+	ep := ManagedEndpoint{Hostname: "web-01", EndpointIP: "10.0.0.5"}
+	matchedBy, ok := MatchHostToEndpoint(ProviderWazuh, host, ep)
+	if !ok || matchedBy != schema.EDRMatchHostname {
+		t.Fatalf("expected hostname match, got %q ok=%v", matchedBy, ok)
+	}
+}
+
+func TestMatchHostToEndpoint_WazuhHostnameRejectedForBadAgentIP(t *testing.T) {
+	host := schema.Host{
+		ID:         uuid.New(),
+		Name:       "web-01",
+		EndpointIP: net.ParseIP("10.0.0.5"),
+	}
+	for _, agentIP := range []string{"", "any", "127.0.0.1"} {
+		ep := ManagedEndpoint{Hostname: "web-01", EndpointIP: agentIP}
+		if _, ok := MatchHostToEndpoint(ProviderWazuh, host, ep); ok {
+			t.Fatalf("expected no match for agent ip %q", agentIP)
+		}
+	}
+}
+
+func TestHostEndpointIPMatches(t *testing.T) {
+	host := schema.Host{EndpointIP: net.ParseIP("203.0.113.10"), EndpointIPv6: net.ParseIP("2001:db8::1")}
+	if !HostEndpointIPMatches(host, "203.0.113.10") {
+		t.Fatal("expected ipv4 match")
+	}
+	if !HostEndpointIPMatches(host, "2001:db8::1") {
+		t.Fatal("expected ipv6 match")
+	}
+	if HostEndpointIPMatches(host, "10.0.0.1") {
+		t.Fatal("expected no match for different ip")
+	}
+	if HostEndpointIPMatches(host, "any") {
+		t.Fatal("expected any to be rejected")
 	}
 }

--- a/pro/integration/edr/sync_test.go
+++ b/pro/integration/edr/sync_test.go
@@ -97,6 +97,24 @@ func TestHostEligibleForEDR_Wazuh(t *testing.T) {
 	}
 }
 
+func TestMatchHostToEndpoint_WazuhSerialFirst(t *testing.T) {
+	host := schema.Host{
+		ID:           uuid.New(),
+		SerialNumber: "SN-42",
+		Name:         "web-01",
+		EndpointIP:   net.ParseIP("10.0.0.5"),
+	}
+	ep := ManagedEndpoint{
+		SerialNumber: "sn-42",
+		Hostname:     "web-01",
+		EndpointIP:   "10.0.0.5",
+	}
+	matchedBy, ok := MatchHostToEndpoint(ProviderWazuh, host, ep)
+	if !ok || matchedBy != schema.EDRMatchSerialNumber {
+		t.Fatalf("expected serial match first, got %q ok=%v", matchedBy, ok)
+	}
+}
+
 func TestMatchHostToEndpoint_WazuhHostIDByName(t *testing.T) {
 	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	host := schema.Host{ID: id, Name: "web-01"}

--- a/pro/integration/edr/wazuh/wazuh.go
+++ b/pro/integration/edr/wazuh/wazuh.go
@@ -85,8 +85,15 @@ func (c *Client) ListManagedEndpoints(ctx context.Context) ([]edrpkg.ManagedEndp
 	if err != nil {
 		return nil, err
 	}
+	serialByAgent, err := c.listHardwareSerials(ctx)
+	if err != nil {
+		serialByAgent = map[string]string{}
+	}
 	out := make([]edrpkg.ManagedEndpoint, 0, len(agents))
 	for _, a := range agents {
+		if serial := serialByAgent[a.ID]; serial != "" {
+			a.SerialNumber = serial
+		}
 		out = append(out, normalizeAgent(a))
 	}
 	return out, nil
@@ -102,8 +109,19 @@ func (c *Client) LookupBySerial(ctx context.Context, serial string) (edrpkg.Mana
 	return ep, err
 }
 
-// LookupForHost resolves a Wazuh agent by host UUID (agent name), then hostname plus endpoint IP.
+// LookupForHost resolves a Wazuh agent by serial_number first, then host UUID
+// (agent name), then hostname plus endpoint IP.
 func (c *Client) LookupForHost(ctx context.Context, h schema.Host) (edrpkg.ManagedEndpoint, string, error) {
+	if serial := strings.TrimSpace(h.SerialNumber); serial != "" {
+		ep, matchedBy, err := c.lookupForSerial(ctx, serial)
+		if err == nil {
+			return ep, matchedBy, nil
+		}
+		if !errors.Is(err, edrpkg.ErrDeviceNotFoundInEDR) {
+			return edrpkg.ManagedEndpoint{}, "", err
+		}
+	}
+
 	if h.ID != uuid.Nil {
 		agent, ok, err := c.lookupAgentByName(ctx, h.ID.String())
 		if err != nil {

--- a/pro/integration/edr/wazuh/wazuh.go
+++ b/pro/integration/edr/wazuh/wazuh.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	edrpkg "github.com/gravitl/netmaker/pro/integration/edr"
 	"github.com/gravitl/netmaker/schema"
 )
@@ -84,15 +85,8 @@ func (c *Client) ListManagedEndpoints(ctx context.Context) ([]edrpkg.ManagedEndp
 	if err != nil {
 		return nil, err
 	}
-	serialByAgent, err := c.listHardwareSerials(ctx)
-	if err != nil {
-		serialByAgent = map[string]string{}
-	}
 	out := make([]edrpkg.ManagedEndpoint, 0, len(agents))
 	for _, a := range agents {
-		if serial := serialByAgent[a.ID]; serial != "" {
-			a.SerialNumber = serial
-		}
 		out = append(out, normalizeAgent(a))
 	}
 	return out, nil
@@ -108,13 +102,61 @@ func (c *Client) LookupBySerial(ctx context.Context, serial string) (edrpkg.Mana
 	return ep, err
 }
 
-// LookupForHost resolves a Wazuh agent by serial_number only.
+// LookupForHost resolves a Wazuh agent by host UUID (agent name), then hostname plus endpoint IP.
 func (c *Client) LookupForHost(ctx context.Context, h schema.Host) (edrpkg.ManagedEndpoint, string, error) {
-	serial := strings.TrimSpace(h.SerialNumber)
-	if serial == "" {
-		return edrpkg.ManagedEndpoint{}, "", edrpkg.ErrDeviceNotFoundInEDR
+	if h.ID != uuid.Nil {
+		agent, ok, err := c.lookupAgentByName(ctx, h.ID.String())
+		if err != nil {
+			return edrpkg.ManagedEndpoint{}, "", err
+		}
+		if ok {
+			return normalizeAgent(agent), schema.EDRMatchHostID, nil
+		}
 	}
-	return c.lookupForSerial(ctx, serial)
+
+	hostName := strings.TrimSpace(h.Name)
+	if hostName != "" {
+		agent, ok, err := c.lookupAgentByName(ctx, hostName)
+		if err != nil {
+			return edrpkg.ManagedEndpoint{}, "", err
+		}
+		if ok && edrpkg.HostEndpointIPMatches(h, agent.IP) {
+			return normalizeAgent(agent), schema.EDRMatchHostname, nil
+		}
+	}
+
+	return edrpkg.ManagedEndpoint{}, "", edrpkg.ErrDeviceNotFoundInEDR
+}
+
+func (c *Client) lookupAgentByName(ctx context.Context, name string) (wazuhAgent, bool, error) {
+	agents, err := c.listAgentsByName(ctx, name)
+	if err != nil {
+		return wazuhAgent{}, false, err
+	}
+	want := strings.TrimSpace(name)
+	for _, a := range agents {
+		if strings.EqualFold(strings.TrimSpace(a.Name), want) {
+			return a, true, nil
+		}
+	}
+	return wazuhAgent{}, false, nil
+}
+
+func (c *Client) listAgentsByName(ctx context.Context, name string) ([]wazuhAgent, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, nil
+	}
+	tok, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	u := c.baseURL + agentsPath + "?name=" + url.QueryEscape(name) + "&limit=10"
+	var data listResponse[wazuhAgent]
+	if err := c.apiGet(ctx, tok, u, &data); err != nil {
+		return nil, err
+	}
+	return data.AffectedItems, nil
 }
 
 func (c *Client) lookupForSerial(ctx context.Context, serial string) (edrpkg.ManagedEndpoint, string, error) {
@@ -316,6 +358,7 @@ func normalizeAgent(a wazuhAgent) edrpkg.ManagedEndpoint {
 		ProviderDeviceID: a.ID,
 		SerialNumber:     a.SerialNumber,
 		Hostname:         a.Name,
+		EndpointIP:       strings.TrimSpace(a.IP),
 		AgentInstalled:   installed,
 		AgentHealthy:     healthy,
 		RiskLevel:        edrpkg.ComputeRiskLevel(signals),

--- a/pro/integration/edr/wazuh/wazuh_test.go
+++ b/pro/integration/edr/wazuh/wazuh_test.go
@@ -3,12 +3,15 @@ package wazuh
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	edrpkg "github.com/gravitl/netmaker/pro/integration/edr"
+	"github.com/gravitl/netmaker/schema"
 )
 
 func TestNormalizeAgent_ActiveHealthy(t *testing.T) {
@@ -16,9 +19,13 @@ func TestNormalizeAgent_ActiveHealthy(t *testing.T) {
 		ID:     "001",
 		Name:   "web-01",
 		Status: "active",
+		IP:     "10.0.0.5",
 	})
 	if !got.AgentHealthy || got.RiskLevel != "none" {
 		t.Fatalf("expected active healthy, got healthy=%v risk=%q", got.AgentHealthy, got.RiskLevel)
+	}
+	if got.EndpointIP != "10.0.0.5" {
+		t.Fatalf("expected endpoint ip on managed endpoint, got %q", got.EndpointIP)
 	}
 }
 
@@ -149,6 +156,128 @@ func TestLookupBySerial_NotFound(t *testing.T) {
 		http:     srv.Client(),
 	}
 	_, err := c.LookupBySerial(context.Background(), "missing")
+	if err == nil || !strings.Contains(err.Error(), edrpkg.ErrDeviceNotFoundInEDR.Error()) {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestLookupForHost_ByHostUUIDName(t *testing.T) {
+	hostID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == authPath:
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data:  json.RawMessage(`{"token":"tok"}`),
+				Error: 0,
+			})
+		case r.URL.Path == agentsPath:
+			if r.URL.Query().Get("name") != hostID.String() {
+				t.Fatalf("name = %q", r.URL.Query().Get("name"))
+			}
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data: json.RawMessage(`{
+					"affected_items":[{"id":"001","name":"` + hostID.String() + `","status":"active","ip":"10.0.0.99"}],
+					"total_affected_items":1
+				}`),
+				Error: 0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, username: "wazuh", password: "wazuh", http: srv.Client()}
+	ep, matchedBy, err := c.LookupForHost(context.Background(), schema.Host{
+		ID:         hostID,
+		Name:       "web-01",
+		EndpointIP: net.ParseIP("203.0.113.1"),
+	})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if matchedBy != schema.EDRMatchHostID || ep.ProviderDeviceID != "001" {
+		t.Fatalf("unexpected match: by=%q ep=%+v", matchedBy, ep)
+	}
+}
+
+func TestLookupForHost_ByHostnameAndEndpointIP(t *testing.T) {
+	hostID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == authPath:
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data:  json.RawMessage(`{"token":"tok"}`),
+				Error: 0,
+			})
+		case r.URL.Path == agentsPath:
+			name := r.URL.Query().Get("name")
+			switch name {
+			case hostID.String():
+				_ = json.NewEncoder(w).Encode(apiEnvelope{
+					Data:  json.RawMessage(`{"affected_items":[],"total_affected_items":0}`),
+					Error: 0,
+				})
+			case "web-01":
+				_ = json.NewEncoder(w).Encode(apiEnvelope{
+					Data: json.RawMessage(`{
+						"affected_items":[{"id":"002","name":"web-01","status":"active","ip":"10.0.0.5"}],
+						"total_affected_items":1
+					}`),
+					Error: 0,
+				})
+			default:
+				t.Fatalf("unexpected name query %q", name)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, username: "wazuh", password: "wazuh", http: srv.Client()}
+	ep, matchedBy, err := c.LookupForHost(context.Background(), schema.Host{
+		ID:         hostID,
+		Name:       "web-01",
+		EndpointIP: net.ParseIP("10.0.0.5"),
+	})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if matchedBy != schema.EDRMatchHostname || ep.ProviderDeviceID != "002" {
+		t.Fatalf("unexpected match: by=%q ep=%+v", matchedBy, ep)
+	}
+}
+
+func TestLookupForHost_HostnameOnlyRejected(t *testing.T) {
+	hostID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == authPath:
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data:  json.RawMessage(`{"token":"tok"}`),
+				Error: 0,
+			})
+		case r.URL.Path == agentsPath:
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data: json.RawMessage(`{
+					"affected_items":[{"id":"002","name":"web-01","status":"active","ip":"10.0.0.9"}],
+					"total_affected_items":1
+				}`),
+				Error: 0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, username: "wazuh", password: "wazuh", http: srv.Client()}
+	_, _, err := c.LookupForHost(context.Background(), schema.Host{
+		ID:         hostID,
+		Name:       "web-01",
+		EndpointIP: net.ParseIP("10.0.0.5"),
+	})
 	if err == nil || !strings.Contains(err.Error(), edrpkg.ErrDeviceNotFoundInEDR.Error()) {
 		t.Fatalf("expected not found, got %v", err)
 	}

--- a/pro/integration/edr/wazuh/wazuh_test.go
+++ b/pro/integration/edr/wazuh/wazuh_test.go
@@ -161,6 +161,64 @@ func TestLookupBySerial_NotFound(t *testing.T) {
 	}
 }
 
+func TestLookupForHost_BySerialFirst(t *testing.T) {
+	hostID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	nameLookupCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == authPath:
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data:  json.RawMessage(`{"token":"tok"}`),
+				Error: 0,
+			})
+		case r.URL.Path == hardwarePath:
+			if r.URL.Query().Get("board_serial") != "SN-42" {
+				t.Fatalf("board_serial = %q", r.URL.Query().Get("board_serial"))
+			}
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data: json.RawMessage(`{
+					"affected_items":[{"agent_id":"001","board_serial":"SN-42"}],
+					"total_affected_items":1
+				}`),
+				Error: 0,
+			})
+		case r.URL.Path == agentsPath:
+			if r.URL.Query().Get("name") != "" {
+				nameLookupCalled = true
+			}
+			if r.URL.Query().Get("agents_list") != "001" {
+				t.Fatalf("agents_list = %q", r.URL.Query().Get("agents_list"))
+			}
+			_ = json.NewEncoder(w).Encode(apiEnvelope{
+				Data: json.RawMessage(`{
+					"affected_items":[{"id":"001","name":"other-name","status":"active","ip":"10.0.0.1"}],
+					"total_affected_items":1
+				}`),
+				Error: 0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, username: "wazuh", password: "wazuh", http: srv.Client()}
+	ep, matchedBy, err := c.LookupForHost(context.Background(), schema.Host{
+		ID:           hostID,
+		SerialNumber: "SN-42",
+		Name:         hostID.String(),
+	})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if matchedBy != schema.EDRMatchSerialNumber || ep.ProviderDeviceID != "001" {
+		t.Fatalf("unexpected match: by=%q ep=%+v", matchedBy, ep)
+	}
+	if nameLookupCalled {
+		t.Fatal("expected serial lookup to succeed without name-based agent query")
+	}
+}
+
 func TestLookupForHost_ByHostUUIDName(t *testing.T) {
 	hostID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/schema/device_edr_state.go
+++ b/schema/device_edr_state.go
@@ -16,6 +16,7 @@ const (
 	EDRMatchEntraDeviceID = "entra_device_id"
 	EDRMatchSerialNumber  = "serial_number"
 	EDRMatchHostname      = "hostname"
+	EDRMatchHostID        = "host_id"
 )
 
 // DeviceEDRState is the per-host snapshot of an EDR provider's view of an endpoint.


### PR DESCRIPTION
Match existing Wazuh fleets by agent name (host UUID, then hostname with endpoint IP) instead of board serial, so posture sync works for customers who already have agents enrolled without re-provisioning.

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
