### PR TITLE
NM-295: publish WSS uplink endpoints for selfsigned and external termination

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   netmaker:
     container_name: netmaker
-    image: gravitl/netmaker:$SERVER_IMAGE_TAG
+    image: abhi9686/netmaker:NM-295
     env_file: ./netmaker.env
     restart: always
     volumes:
@@ -26,7 +26,7 @@ services:
 
   netmaker-ui:
     container_name: netmaker-ui
-    image: gravitl/netmaker-ui:$UI_IMAGE_TAG
+    image: gravitl/netmaker-ui:v1.6.0
     env_file: ./netmaker.env
     environment:
       # config-dependant vars

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   netmaker:
     container_name: netmaker
-    image: abhi9686/netmaker:NM-295
+    image: gravitl/netmaker:$SERVER_IMAGE_TAG
     env_file: ./netmaker.env
     restart: always
     volumes:
@@ -26,7 +26,7 @@ services:
 
   netmaker-ui:
     container_name: netmaker-ui
-    image: gravitl/netmaker-ui:v1.6.0
+    image: gravitl/netmaker-ui:$UI_IMAGE_TAG
     env_file: ./netmaker.env
     environment:
       # config-dependant vars

--- a/controllers/gateway.go
+++ b/controllers/gateway.go
@@ -98,7 +98,7 @@ func createGateway(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.TcpProxyEnabled {
-		options = append(options, orchestrator.WithTcpProxy(true, req.TcpProxyListenPort))
+		options = append(options, orchestrator.WithTcpProxy(true, req.TcpProxyListenPort, req.TcpProxyTLSMode, req.TcpProxyListenAddr, req.TcpProxyPublicHostname))
 	}
 
 	err = orchestrator.GetRepository().NodeOrchestrator().ValidateCreateGateway(r.Context(), node, options...)
@@ -267,6 +267,10 @@ func deleteGateway(w http.ResponseWriter, r *http.Request) {
 					if err := host.Get(r.Context()); err == nil {
 						host.TcpProxyEnabled = false
 						host.TcpProxyListenPort = 0
+						host.TcpProxyTLSMode = ""
+						host.TcpProxyListenAddr = ""
+						host.TcpProxyPublicHostname = ""
+						host.TcpProxyCertFingerprint = ""
 						_ = host.SetTcpProxy(r.Context())
 					}
 				}
@@ -430,8 +434,15 @@ func updateGatewayTcpProxy(w http.ResponseWriter, r *http.Request) {
 		if node.TcpProxyListenPort <= 0 {
 			node.TcpProxyListenPort = schema.DefaultTcpProxyListenPort
 		}
+		mode, err := schema.NormaliseTcpProxyTLSMode(req.TLSMode)
+		if err != nil {
+			logic.ReturnErrorResponse(w, r, logic.FormatError(err, logic.BadReq))
+			return
+		}
+		node.TcpProxyTLSMode = mode
 	} else {
 		node.TcpProxyListenPort = 0
+		node.TcpProxyTLSMode = ""
 		if err := db.FromContext(r.Context()).Model(&schema.Node{}).
 			Where("relayed_by_node_id = ? AND use_tcp_uplink = ?", node.ID, true).
 			Update("use_tcp_uplink", false).Error; err != nil {
@@ -450,6 +461,24 @@ func updateGatewayTcpProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	host.TcpProxyEnabled = node.TcpProxyEnabled
 	host.TcpProxyListenPort = node.TcpProxyListenPort
+	host.TcpProxyTLSMode = node.TcpProxyTLSMode
+	if req.Enabled {
+		host.TcpProxyListenAddr = req.ListenAddr
+		publicHostname := ""
+		if node.TcpProxyTLSMode == schema.TcpProxyTLSModeProxy {
+			var err error
+			publicHostname, err = schema.NormaliseTcpProxyPublicHostname(req.PublicHostname)
+			if err != nil {
+				logic.ReturnErrorResponse(w, r, logic.FormatError(err, logic.BadReq))
+				return
+			}
+		}
+		host.TcpProxyPublicHostname = publicHostname
+	} else {
+		host.TcpProxyListenAddr = ""
+		host.TcpProxyPublicHostname = ""
+		host.TcpProxyCertFingerprint = ""
+	}
 	if err := host.SetTcpProxy(r.Context()); err != nil {
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, logic.Internal))
 		return

--- a/controllers/gateway.go
+++ b/controllers/gateway.go
@@ -472,6 +472,8 @@ func updateGatewayTcpProxy(w http.ResponseWriter, r *http.Request) {
 				logic.ReturnErrorResponse(w, r, logic.FormatError(err, logic.BadReq))
 				return
 			}
+			// Drop any fingerprint left over from a prior selfsigned config.
+			host.TcpProxyCertFingerprint = ""
 		}
 		host.TcpProxyPublicHostname = publicHostname
 	} else {

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -45,6 +45,6 @@ broker.{$NM_DOMAIN} {
 }
 
 
-# default-gateway.{$NM_DOMAIN} {
-#     reverse_proxy /uplink/v1 host.docker.internal:6443
-# }
+default-gateway.{$NM_DOMAIN} {
+    reverse_proxy /uplink/v1 host.docker.internal:6443
+}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -43,3 +43,8 @@ broker.{$NM_DOMAIN} {
 		}
 	reverse_proxy @ws mq:8883   # For EMQX websockets use `reverse_proxy @ws mq:8083`
 }
+
+
+# default-gateway.{$NM_DOMAIN} {
+#     reverse_proxy /uplink/v1 host.docker.internal:6443
+# }

--- a/docker/Caddyfile-pro
+++ b/docker/Caddyfile-pro
@@ -73,6 +73,11 @@ broker.{$NM_DOMAIN} {
 	reverse_proxy @ws mq:8883
 }
 
+
+# default-gateway.{$NM_DOMAIN} {
+#     reverse_proxy /uplink/v1 host.docker.internal:6443
+# }
+
 # GRPC
 # https://grpc.{$NM_DOMAIN} {
 #     reverse_proxy netmaker-exporter:50051 {

--- a/docker/Caddyfile-pro
+++ b/docker/Caddyfile-pro
@@ -74,9 +74,9 @@ broker.{$NM_DOMAIN} {
 }
 
 
-# default-gateway.{$NM_DOMAIN} {
-#     reverse_proxy /uplink/v1 host.docker.internal:6443
-# }
+default-gateway.{$NM_DOMAIN} {
+    reverse_proxy /uplink/v1 host.docker.internal:6443
+}
 
 # GRPC
 # https://grpc.{$NM_DOMAIN} {

--- a/logic/hosts.go
+++ b/logic/hosts.go
@@ -335,6 +335,12 @@ func UpdateHostFromClient(ctx context.Context, newHost, currHost *schema.Host) (
 		sendPeerUpdate = true
 		peerUpdateReasons = append(peerUpdateReasons, "nat_type")
 	}
+	// Gateway reports self-signed uplink cert fingerprint after LoadOrCreateServerTLS.
+	if newHost.TcpProxyCertFingerprint != "" && newHost.TcpProxyCertFingerprint != currHost.TcpProxyCertFingerprint {
+		currHost.TcpProxyCertFingerprint = newHost.TcpProxyCertFingerprint
+		sendPeerUpdate = true
+		peerUpdateReasons = append(peerUpdateReasons, "tcp_proxy_cert_fingerprint")
+	}
 
 	if sendPeerUpdate {
 		slog.Debug("UpdateHostFromClient: sendPeerUpdate",

--- a/logic/nodes.go
+++ b/logic/nodes.go
@@ -709,7 +709,21 @@ func ConvertSchemaNodeToModelsNode(_node *schema.Node) *models.Node {
 				}
 				return _node.TcpProxyListenPort
 			}(),
-			UseTcpUplink: _node.UseTcpUplink,
+			TcpProxyTLSMode: func() string {
+				if _node.Host.TcpProxyTLSMode != "" {
+					return _node.Host.TcpProxyTLSMode
+				}
+				if _node.TcpProxyTLSMode != "" {
+					return _node.TcpProxyTLSMode
+				}
+				if _node.TcpProxyEnabled || _node.Host.TcpProxyEnabled {
+					return schema.TcpProxyTLSModeSelfSigned
+				}
+				return ""
+			}(),
+			TcpProxyListenAddr:     _node.Host.TcpProxyListenAddr,
+			TcpProxyPublicHostname: _node.Host.TcpProxyPublicHostname,
+			UseTcpUplink:           _node.UseTcpUplink,
 		},
 		PendingDelete:                      _node.PendingDelete,
 		LastModified:                       _node.UpdatedAt,
@@ -878,6 +892,7 @@ func ConvertModelsNodeToSchemaNode(node *models.Node) *schema.Node {
 		IsInternetGateway:                 node.IsGw && node.IsInternetGateway,
 		TcpProxyEnabled:                   node.TcpProxyEnabled,
 		TcpProxyListenPort:                node.TcpProxyListenPort,
+		TcpProxyTLSMode:                   node.TcpProxyTLSMode,
 		AdditionalGatewayEndpoints:        additionalEndpoints,
 		RelayedClients:                    relayedClients,
 		RelayedIGWClients:                 relayedIGWClients,

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -557,16 +557,20 @@ func GetPeerUpdateForHost(ctx context.Context, network string, host *schema.Host
 			// pass network="" (all networks on the host); only then include every network's peers.
 			if (network == "" || node.Network == network) && !peerConfig.Remove && len(peerConfig.AllowedIPs) > 0 {
 				ida := models.IDandAddr{
-					ID:               peer.ID.String(),
-					HostID:           peerHost.ID.String(),
-					Address:          peer.PrimaryAddress(),
-					Name:             peerHost.Name,
-					Network:          peer.Network,
-					ListenPort:       peerHost.ListenPort,
-					TcpProxyEndpoint: tcpProxyEndpointForPeer(&peer, peerHost, host),
+					ID:                      peer.ID.String(),
+					HostID:                  peerHost.ID.String(),
+					Address:                 peer.PrimaryAddress(),
+					Name:                    peerHost.Name,
+					Network:                 peer.Network,
+					ListenPort:              peerHost.ListenPort,
+					TcpProxyEndpoint:        tcpProxyEndpointForPeer(&peer, peerHost, host),
+					TcpProxyCertFingerprint: tcpProxyCertFingerprintForPeer(&peer, peerHost),
 				}
 				if prev, ok := hostPeerUpdate.PeerIDs[peerHost.PublicKey.String()]; ok && ida.TcpProxyEndpoint == "" && prev.TcpProxyEndpoint != "" {
 					ida.TcpProxyEndpoint = prev.TcpProxyEndpoint
+				}
+				if prev, ok := hostPeerUpdate.PeerIDs[peerHost.PublicKey.String()]; ok && ida.TcpProxyCertFingerprint == "" && prev.TcpProxyCertFingerprint != "" {
+					ida.TcpProxyCertFingerprint = prev.TcpProxyCertFingerprint
 				}
 				hostPeerUpdate.PeerIDs[peerHost.PublicKey.String()] = ida
 				hostPeerUpdate.NodePeers = append(hostPeerUpdate.NodePeers, nodePeer)
@@ -840,10 +844,24 @@ func buildHostNetworkInfo(peerHost *schema.Host, peer *models.Node, prev *models
 		if info.TcpProxyListenPort <= 0 {
 			info.TcpProxyListenPort = schema.DefaultTcpProxyListenPort
 		}
+		info.TcpProxyTLSMode = peerHost.TcpProxyTLSMode
+		if info.TcpProxyTLSMode == "" {
+			info.TcpProxyTLSMode = peer.TcpProxyTLSMode
+		}
+		if info.TcpProxyTLSMode == "" {
+			info.TcpProxyTLSMode = schema.TcpProxyTLSModeSelfSigned
+		}
+		info.TcpProxyListenAddr = peerHost.TcpProxyListenAddr
+		info.TcpProxyPublicHostname = peerHost.TcpProxyPublicHostname
+		info.TcpProxyCertFingerprint = peerHost.TcpProxyCertFingerprint
 	} else if prev != nil && prev.TcpProxyEnabled {
 		// Preserve TCP settings from another network's gateway node on the same host.
 		info.TcpProxyEnabled = prev.TcpProxyEnabled
 		info.TcpProxyListenPort = prev.TcpProxyListenPort
+		info.TcpProxyTLSMode = prev.TcpProxyTLSMode
+		info.TcpProxyListenAddr = prev.TcpProxyListenAddr
+		info.TcpProxyPublicHostname = prev.TcpProxyPublicHostname
+		info.TcpProxyCertFingerprint = prev.TcpProxyCertFingerprint
 	}
 	return info
 }
@@ -856,23 +874,66 @@ func tcpProxyEndpointForPeer(peer *models.Node, peerHost *schema.Host, clientHos
 	if !tcpEnabled {
 		return ""
 	}
-	port := peerHost.TcpProxyListenPort
-	if port <= 0 {
-		port = peer.TcpProxyListenPort
+	tlsMode := peerHost.TcpProxyTLSMode
+	if tlsMode == "" {
+		tlsMode = peer.TcpProxyTLSMode
 	}
-	if port <= 0 {
-		port = schema.DefaultTcpProxyListenPort
+	tlsMode, _ = schema.NormaliseTcpProxyTLSMode(tlsMode)
+
+	// External termination: clients dial the public reverse-proxy port
+	// (default 443, overridable via TCP_PROXY_PUBLIC_PORT), not the backend
+	// listen port behind Caddy/nginx/etc.
+	port := servercfg.GetTcpProxyPublicPort()
+	if tlsMode != schema.TcpProxyTLSModeProxy {
+		port = peerHost.TcpProxyListenPort
+		if port <= 0 {
+			port = peer.TcpProxyListenPort
+		}
+		if port <= 0 {
+			port = schema.DefaultTcpProxyListenPort
+		}
 	}
-	var ip net.IP
-	if clientHost.EndpointIP != nil && peerHost.EndpointIP != nil {
-		ip = peerHost.EndpointIP
-	} else if clientHost.EndpointIPv6 != nil && peerHost.EndpointIPv6 != nil {
-		ip = peerHost.EndpointIPv6
+
+	hostPart := ""
+	if tlsMode == schema.TcpProxyTLSModeProxy {
+		if hn, err := schema.NormaliseTcpProxyPublicHostname(peerHost.TcpProxyPublicHostname); err == nil && hn != "" {
+			hostPart = hn
+		}
 	}
-	if ip == nil {
+	if hostPart == "" {
+		var ip net.IP
+		if clientHost.EndpointIP != nil && peerHost.EndpointIP != nil {
+			ip = peerHost.EndpointIP
+		} else if clientHost.EndpointIPv6 != nil && peerHost.EndpointIPv6 != nil {
+			ip = peerHost.EndpointIPv6
+		}
+		if ip == nil {
+			return ""
+		}
+		hostPart = ip.String()
+	}
+	return fmt.Sprintf("wss://%s/uplink/v1", net.JoinHostPort(hostPart, strconv.Itoa(port)))
+}
+
+func tcpProxyCertFingerprintForPeer(peer *models.Node, peerHost *schema.Host) string {
+	if peer == nil || peerHost == nil || !peer.IsGw {
 		return ""
 	}
-	return net.JoinHostPort(ip.String(), strconv.Itoa(port))
+	tcpEnabled := peerHost.TcpProxyEnabled || peer.TcpProxyEnabled
+	if !tcpEnabled {
+		return ""
+	}
+	tlsMode := peerHost.TcpProxyTLSMode
+	if tlsMode == "" {
+		tlsMode = peer.TcpProxyTLSMode
+	}
+	tlsMode, _ = schema.NormaliseTcpProxyTLSMode(tlsMode)
+	// External termination uses the reverse-proxy's public cert; do not pin the
+	// gateway's (possibly stale) self-signed fingerprint.
+	if tlsMode == schema.TcpProxyTLSModeProxy {
+		return ""
+	}
+	return peerHost.TcpProxyCertFingerprint
 }
 
 func filterConflictingEgressRoutes(node, peer models.Node) []string {

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -853,7 +853,11 @@ func buildHostNetworkInfo(peerHost *schema.Host, peer *models.Node, prev *models
 		}
 		info.TcpProxyListenAddr = peerHost.TcpProxyListenAddr
 		info.TcpProxyPublicHostname = peerHost.TcpProxyPublicHostname
-		info.TcpProxyCertFingerprint = peerHost.TcpProxyCertFingerprint
+		// External termination uses the reverse-proxy cert; do not publish a
+		// (possibly stale) self-signed fingerprint to clients.
+		if info.TcpProxyTLSMode != schema.TcpProxyTLSModeProxy {
+			info.TcpProxyCertFingerprint = peerHost.TcpProxyCertFingerprint
+		}
 	} else if prev != nil && prev.TcpProxyEnabled {
 		// Preserve TCP settings from another network's gateway node on the same host.
 		info.TcpProxyEnabled = prev.TcpProxyEnabled
@@ -861,7 +865,9 @@ func buildHostNetworkInfo(peerHost *schema.Host, peer *models.Node, prev *models
 		info.TcpProxyTLSMode = prev.TcpProxyTLSMode
 		info.TcpProxyListenAddr = prev.TcpProxyListenAddr
 		info.TcpProxyPublicHostname = prev.TcpProxyPublicHostname
-		info.TcpProxyCertFingerprint = prev.TcpProxyCertFingerprint
+		if prev.TcpProxyTLSMode != schema.TcpProxyTLSModeProxy {
+			info.TcpProxyCertFingerprint = prev.TcpProxyCertFingerprint
+		}
 	}
 	return info
 }

--- a/logic/peers_test.go
+++ b/logic/peers_test.go
@@ -273,3 +273,52 @@ func TestGetAllowedIPsNonGwExitAdvertisesRelayedClientRanges(t *testing.T) {
 	assert.True(t, hasOverlay, "exit client's overlay IP should appear on peers' wg AllowedIPs")
 	assert.True(t, hasLAN, "exit client's egress range should appear on peers' wg AllowedIPs when exit is not a GW")
 }
+
+func TestTcpProxyEndpointForPeerProxyModeUsesPublic443(t *testing.T) {
+	gwIP := net.ParseIP("203.0.113.10")
+	clientIP := net.ParseIP("198.51.100.20")
+	peer := &models.Node{
+		CommonNode: models.CommonNode{
+			IsGw:               true,
+			TcpProxyEnabled:    true,
+			TcpProxyListenPort: 51822,
+			TcpProxyTLSMode:    schema.TcpProxyTLSModeProxy,
+		},
+	}
+	peerHost := &schema.Host{
+		TcpProxyEnabled:    true,
+		TcpProxyListenPort: 51822,
+		TcpProxyTLSMode:    schema.TcpProxyTLSModeProxy,
+		EndpointIP:         gwIP,
+	}
+	clientHost := &schema.Host{EndpointIP: clientIP}
+
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "")
+	got := tcpProxyEndpointForPeer(peer, peerHost, clientHost)
+	want := "wss://203.0.113.10:443/uplink/v1"
+	assert.Equal(t, want, got)
+
+	peerHost.TcpProxyPublicHostname = "gateway.example.com"
+	got = tcpProxyEndpointForPeer(peer, peerHost, clientHost)
+	want = "wss://gateway.example.com:443/uplink/v1"
+	assert.Equal(t, want, got)
+
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "8443")
+	got = tcpProxyEndpointForPeer(peer, peerHost, clientHost)
+	want = "wss://gateway.example.com:8443/uplink/v1"
+	assert.Equal(t, want, got)
+
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "")
+	peerHost.TcpProxyPublicHostname = ""
+	peerHost.TcpProxyTLSMode = schema.TcpProxyTLSModeSelfSigned
+	peer.TcpProxyTLSMode = schema.TcpProxyTLSModeSelfSigned
+	got = tcpProxyEndpointForPeer(peer, peerHost, clientHost)
+	want = "wss://203.0.113.10:51822/uplink/v1"
+	assert.Equal(t, want, got)
+
+	assert.Empty(t, tcpProxyCertFingerprintForPeer(peer, &schema.Host{
+		TcpProxyEnabled:         true,
+		TcpProxyTLSMode:         schema.TcpProxyTLSModeProxy,
+		TcpProxyCertFingerprint: "abc",
+	}))
+}

--- a/models/api_host.go
+++ b/models/api_host.go
@@ -163,12 +163,24 @@ func (a *ApiHost) ConvertAPIHostToNMHost(currentHost *schema.Host) *schema.Host 
 	h.AutoUpdate = a.AutoUpdate
 	h.DNS = strings.ToLower(a.DNS)
 	h.EnableFlowLogs = a.EnableFlowLogs
-	h.TcpProxyEnabled = currentHost.TcpProxyEnabled
-	h.TcpProxyListenPort = currentHost.TcpProxyListenPort
-	h.TcpProxyTLSMode = currentHost.TcpProxyTLSMode
-	h.TcpProxyListenAddr = currentHost.TcpProxyListenAddr
-	h.TcpProxyPublicHostname = currentHost.TcpProxyPublicHostname
-	h.TcpProxyCertFingerprint = currentHost.TcpProxyCertFingerprint
+	h.TcpProxyEnabled = a.TcpProxyEnabled
+	h.TcpProxyListenPort = a.TcpProxyListenPort
+	if mode, err := schema.NormaliseTcpProxyTLSMode(a.TcpProxyTLSMode); err == nil {
+		h.TcpProxyTLSMode = mode
+	} else {
+		h.TcpProxyTLSMode = currentHost.TcpProxyTLSMode
+	}
+	h.TcpProxyListenAddr = a.TcpProxyListenAddr
+	if hn, err := schema.NormaliseTcpProxyPublicHostname(a.TcpProxyPublicHostname); err == nil {
+		h.TcpProxyPublicHostname = hn
+	} else {
+		h.TcpProxyPublicHostname = currentHost.TcpProxyPublicHostname
+	}
+	if h.TcpProxyTLSMode == schema.TcpProxyTLSModeProxy {
+		h.TcpProxyCertFingerprint = ""
+	} else {
+		h.TcpProxyCertFingerprint = currentHost.TcpProxyCertFingerprint
+	}
 	h.Location = currentHost.Location
 	h.CountryCode = currentHost.CountryCode
 	h.EntraDeviceID = currentHost.EntraDeviceID

--- a/models/api_host.go
+++ b/models/api_host.go
@@ -26,6 +26,10 @@ type ApiHost struct {
 	WgPublicListenPort  int        `json:"wg_public_listen_port" yaml:"wg_public_listen_port"`
 	TcpProxyEnabled     bool       `json:"tcp_proxy_enabled"`
 	TcpProxyListenPort  int        `json:"tcp_proxy_listen_port"`
+	TcpProxyTLSMode     string     `json:"tcp_proxy_tls_mode"`
+	TcpProxyListenAddr     string     `json:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string     `json:"tcp_proxy_public_hostname,omitempty"`
+	TcpProxyCertFingerprint string `json:"tcp_proxy_cert_fingerprint,omitempty"`
 	MTU                 int        `json:"mtu"                   yaml:"mtu"`
 	Interfaces          []ApiIface `json:"interfaces"            yaml:"interfaces"`
 	DefaultInterface    string     `json:"defaultinterface"      yaml:"defautlinterface"`
@@ -90,6 +94,10 @@ func NewApiHostFromSchemaHost(h *schema.Host) *ApiHost {
 	a.WgPublicListenPort = h.WgPublicListenPort
 	a.TcpProxyEnabled = h.TcpProxyEnabled
 	a.TcpProxyListenPort = h.TcpProxyListenPort
+	a.TcpProxyTLSMode = h.TcpProxyTLSMode
+	a.TcpProxyListenAddr = h.TcpProxyListenAddr
+	a.TcpProxyPublicHostname = h.TcpProxyPublicHostname
+	a.TcpProxyCertFingerprint = h.TcpProxyCertFingerprint
 	a.PublicKey = h.PublicKey.String()
 	a.Verbosity = h.Verbosity
 	a.Version = h.Version
@@ -157,6 +165,10 @@ func (a *ApiHost) ConvertAPIHostToNMHost(currentHost *schema.Host) *schema.Host 
 	h.EnableFlowLogs = a.EnableFlowLogs
 	h.TcpProxyEnabled = currentHost.TcpProxyEnabled
 	h.TcpProxyListenPort = currentHost.TcpProxyListenPort
+	h.TcpProxyTLSMode = currentHost.TcpProxyTLSMode
+	h.TcpProxyListenAddr = currentHost.TcpProxyListenAddr
+	h.TcpProxyPublicHostname = currentHost.TcpProxyPublicHostname
+	h.TcpProxyCertFingerprint = currentHost.TcpProxyCertFingerprint
 	h.Location = currentHost.Location
 	h.CountryCode = currentHost.CountryCode
 	h.EntraDeviceID = currentHost.EntraDeviceID

--- a/models/api_node.go
+++ b/models/api_node.go
@@ -43,7 +43,10 @@ type ApiNode struct {
 	AutoAssignGateway  bool              `json:"auto_assign_gw"`
 	TcpProxyEnabled    bool              `json:"tcp_proxy_enabled"`
 	TcpProxyListenPort int               `json:"tcp_proxy_listen_port"`
-	UseTcpUplink       bool              `json:"use_tcp_uplink"`
+	TcpProxyTLSMode    string            `json:"tcp_proxy_tls_mode"`
+	TcpProxyListenAddr     string            `json:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string            `json:"tcp_proxy_public_hostname,omitempty"`
+	UseTcpUplink           bool              `json:"use_tcp_uplink"`
 	//AutoRelayedBy                 uuid.UUID           `json:"auto_relayed_by"`
 	RelayedBy                     string              `json:"relayedby" bson:"relayedby" yaml:"relayedby"`
 	RelayedNodes                  []string            `json:"relaynodes" yaml:"relayedNodes"`
@@ -178,6 +181,9 @@ func (a *ApiNode) ConvertToServerNode(currentNode *Node) *Node {
 	// wipe these flags when the payload omits them (bool zero value is false).
 	convertedNode.TcpProxyEnabled = currentNode.TcpProxyEnabled
 	convertedNode.TcpProxyListenPort = currentNode.TcpProxyListenPort
+	convertedNode.TcpProxyTLSMode = currentNode.TcpProxyTLSMode
+	convertedNode.TcpProxyListenAddr = currentNode.TcpProxyListenAddr
+	convertedNode.TcpProxyPublicHostname = currentNode.TcpProxyPublicHostname
 	convertedNode.UseTcpUplink = currentNode.UseTcpUplink
 	convertedNode.Status = currentNode.Status
 	convertedNode.AutoRelayedPeers = currentNode.AutoRelayedPeers
@@ -239,6 +245,9 @@ func (nm *Node) ConvertToAPINode() *ApiNode {
 	apiNode.AutoAssignGateway = nm.AutoAssignGateway
 	apiNode.TcpProxyEnabled = nm.TcpProxyEnabled
 	apiNode.TcpProxyListenPort = nm.TcpProxyListenPort
+	apiNode.TcpProxyTLSMode = nm.TcpProxyTLSMode
+	apiNode.TcpProxyListenAddr = nm.TcpProxyListenAddr
+	apiNode.TcpProxyPublicHostname = nm.TcpProxyPublicHostname
 	apiNode.UseTcpUplink = nm.UseTcpUplink
 	apiNode.IsIngressGateway = nm.IsIngressGateway
 	apiNode.IngressDns = nm.IngressDNS

--- a/models/gateway.go
+++ b/models/gateway.go
@@ -4,14 +4,20 @@ type CreateGwReq struct {
 	IngressRequest
 	RelayRequest
 	InetNodeReq
-	TcpProxyEnabled    bool `json:"tcp_proxy_enabled"`
-	TcpProxyListenPort int  `json:"tcp_proxy_listen_port"`
+	TcpProxyEnabled        bool   `json:"tcp_proxy_enabled"`
+	TcpProxyListenPort     int    `json:"tcp_proxy_listen_port"`
+	TcpProxyTLSMode        string `json:"tcp_proxy_tls_mode"`
+	TcpProxyListenAddr     string `json:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string `json:"tcp_proxy_public_hostname,omitempty"`
 }
 
 // TcpProxyReq updates TCP proxy listen settings (persisted on host; node kept in sync for API).
 type TcpProxyReq struct {
-	Enabled    bool `json:"enabled"`
-	ListenPort int  `json:"listen_port"`
+	Enabled        bool   `json:"enabled"`
+	ListenPort     int    `json:"listen_port"`
+	TLSMode        string `json:"tls_mode"`
+	ListenAddr     string `json:"listen_addr,omitempty"`
+	PublicHostname string `json:"public_hostname,omitempty"`
 }
 
 type DeleteGw struct {

--- a/models/host.go
+++ b/models/host.go
@@ -61,6 +61,10 @@ type Host struct {
 	WgPublicListenPort  int              `json:"wg_public_listen_port"   yaml:"wg_public_listen_port"`
 	TcpProxyEnabled     bool             `json:"tcp_proxy_enabled"       yaml:"tcp_proxy_enabled"`
 	TcpProxyListenPort  int              `json:"tcp_proxy_listen_port"   yaml:"tcp_proxy_listen_port"`
+	TcpProxyTLSMode     string           `json:"tcp_proxy_tls_mode"      yaml:"tcp_proxy_tls_mode"`
+	TcpProxyListenAddr     string           `json:"tcp_proxy_listen_addr,omitempty" yaml:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string           `json:"tcp_proxy_public_hostname,omitempty" yaml:"tcp_proxy_public_hostname,omitempty"`
+	TcpProxyCertFingerprint string       `json:"tcp_proxy_cert_fingerprint,omitempty" yaml:"tcp_proxy_cert_fingerprint,omitempty"`
 	MTU                 int              `json:"mtu"                     yaml:"mtu"`
 	PublicKey           wgtypes.Key      `json:"publickey"               yaml:"publickey"`
 	MacAddress          net.HardwareAddr `json:"macaddress"              yaml:"macaddress"`

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -18,7 +18,8 @@ type IDandAddr struct {
 	ListenPort       int    `json:"listen_port" yaml:"listen_port"`
 	IsExtClient      bool   `json:"is_extclient"`
 	UserName         string `json:"username"`
-	TcpProxyEndpoint string `json:"tcp_proxy_endpoint,omitempty"` // host:port when peer is a TCP-enabled gateway
+	TcpProxyEndpoint string `json:"tcp_proxy_endpoint,omitempty"` // wss://host:port/uplink/v1 when peer is a TCP-enabled gateway
+	TcpProxyCertFingerprint string `json:"tcp_proxy_cert_fingerprint,omitempty"`
 }
 
 // HostInfoMap - map of host public keys to host networking info
@@ -33,6 +34,10 @@ type HostNetworkInfo struct {
 	Version            string         `json:"version"`
 	TcpProxyEnabled    bool           `json:"tcp_proxy_enabled,omitempty"`
 	TcpProxyListenPort int            `json:"tcp_proxy_listen_port,omitempty"`
+	TcpProxyTLSMode    string         `json:"tcp_proxy_tls_mode,omitempty"`
+	TcpProxyListenAddr     string         `json:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string         `json:"tcp_proxy_public_hostname,omitempty"`
+	TcpProxyCertFingerprint string    `json:"tcp_proxy_cert_fingerprint,omitempty"`
 }
 
 // PeerMap - peer map for ids and addresses in metrics

--- a/models/node.go
+++ b/models/node.go
@@ -47,7 +47,10 @@ type CommonNode struct {
 	AutoAssignGateway   bool      `json:"auto_assign_gw"`
 	TcpProxyEnabled     bool      `json:"tcp_proxy_enabled"`
 	TcpProxyListenPort  int       `json:"tcp_proxy_listen_port"`
-	UseTcpUplink        bool      `json:"use_tcp_uplink"`
+	TcpProxyTLSMode     string    `json:"tcp_proxy_tls_mode"`
+	TcpProxyListenAddr     string    `json:"tcp_proxy_listen_addr,omitempty"`
+	TcpProxyPublicHostname string    `json:"tcp_proxy_public_hostname,omitempty"`
+	UseTcpUplink           bool      `json:"use_tcp_uplink"`
 }
 
 // Node - a model of a network node

--- a/orchestrator/node.go
+++ b/orchestrator/node.go
@@ -223,12 +223,27 @@ func (n *NodeOrchestrator) CreateGateway(ctx context.Context, node *schema.Node,
 		if listenPort <= 0 {
 			listenPort = schema.DefaultTcpProxyListenPort
 		}
+		tlsMode, err := schema.NormaliseTcpProxyTLSMode(ops.tcpProxyTLSMode)
+		if err != nil {
+			return err
+		}
+		publicHostname := ""
+		if tlsMode == schema.TcpProxyTLSModeProxy {
+			publicHostname, err = schema.NormaliseTcpProxyPublicHostname(ops.tcpProxyPublicHostname)
+			if err != nil {
+				return err
+			}
+		}
 		node.TcpProxyEnabled = true
 		node.TcpProxyListenPort = listenPort
+		node.TcpProxyTLSMode = tlsMode
 		// Listen is host-level; keep node fields synced for API/UI.
 		if node.Host != nil {
 			node.Host.TcpProxyEnabled = true
 			node.Host.TcpProxyListenPort = listenPort
+			node.Host.TcpProxyTLSMode = tlsMode
+			node.Host.TcpProxyListenAddr = ops.tcpProxyListenAddr
+			node.Host.TcpProxyPublicHostname = publicHostname
 			if err := node.Host.SetTcpProxy(ctx); err != nil {
 				return err
 			}
@@ -239,6 +254,9 @@ func (n *NodeOrchestrator) CreateGateway(ctx context.Context, node *schema.Node,
 				if err := host.Get(ctx); err == nil {
 					host.TcpProxyEnabled = true
 					host.TcpProxyListenPort = listenPort
+					host.TcpProxyTLSMode = tlsMode
+					host.TcpProxyListenAddr = ops.tcpProxyListenAddr
+					host.TcpProxyPublicHostname = publicHostname
 					_ = host.SetTcpProxy(ctx)
 				}
 			}

--- a/orchestrator/options.go
+++ b/orchestrator/options.go
@@ -13,6 +13,9 @@ type Options struct {
 	igwClients            []string
 	tcpProxyEnabled       bool
 	tcpProxyListenPort    int
+	tcpProxyTLSMode       string
+	tcpProxyListenAddr    string
+	tcpProxyPublicHostname string
 	setTcpProxy           bool
 	inheritedAuth         bool
 	replicatedAuth        bool
@@ -73,11 +76,16 @@ func WithInternetGateway(igwClients []string) Option {
 }
 
 // WithTcpProxy enables TCP proxy listen settings when creating a gateway.
-func WithTcpProxy(enabled bool, listenPort int) Option {
+// tlsMode may be empty (defaults to selfsigned). listenAddr is optional (e.g. 127.0.0.1).
+// publicHostname is used when tlsMode is proxy (clients dial this DNS name).
+func WithTcpProxy(enabled bool, listenPort int, tlsMode, listenAddr, publicHostname string) Option {
 	return func(o *Options) *Options {
 		o.setTcpProxy = true
 		o.tcpProxyEnabled = enabled
 		o.tcpProxyListenPort = listenPort
+		o.tcpProxyTLSMode = tlsMode
+		o.tcpProxyListenAddr = listenAddr
+		o.tcpProxyPublicHostname = publicHostname
 		return o
 	}
 }

--- a/schema/hosts.go
+++ b/schema/hosts.go
@@ -138,10 +138,19 @@ type Host struct {
 	Debug               bool                        `json:"debug" yaml:"debug"`
 	ListenPort          int                         `json:"listenport" yaml:"listenport"`
 	WgPublicListenPort  int                         `json:"wg_public_listen_port" yaml:"wg_public_listen_port"`
-	// TcpProxyEnabled: host accepts TCP/TLS framed WG uplinks (gateway listen is host-level).
+	// TcpProxyEnabled: host accepts TCP/WSS framed WG uplinks (gateway listen is host-level).
 	TcpProxyEnabled bool `json:"tcp_proxy_enabled" yaml:"tcp_proxy_enabled"`
-	// TcpProxyListenPort: TCP listen port when TcpProxyEnabled (default 443 if enabled with port 0).
+	// TcpProxyListenPort: listen port when TcpProxyEnabled (default 443 if enabled with port 0).
 	TcpProxyListenPort int `json:"tcp_proxy_listen_port" yaml:"tcp_proxy_listen_port"`
+	// TcpProxyTLSMode: selfsigned (default) or proxy. Empty means selfsigned.
+	TcpProxyTLSMode string `json:"tcp_proxy_tls_mode" yaml:"tcp_proxy_tls_mode"`
+	// TcpProxyListenAddr: optional bind address (e.g. 127.0.0.1). Empty means all interfaces (:port).
+	TcpProxyListenAddr string `json:"tcp_proxy_listen_addr,omitempty" yaml:"tcp_proxy_listen_addr,omitempty"`
+	// TcpProxyPublicHostname: public DNS name clients dial when TLS mode is proxy
+	// (e.g. gateway.example.com). Empty falls back to EndpointIP.
+	TcpProxyPublicHostname string `json:"tcp_proxy_public_hostname,omitempty" yaml:"tcp_proxy_public_hostname,omitempty"`
+	// TcpProxyCertFingerprint: SHA-256 hex of the leaf cert when tls mode is selfsigned.
+	TcpProxyCertFingerprint string `json:"tcp_proxy_cert_fingerprint,omitempty" yaml:"tcp_proxy_cert_fingerprint,omitempty"`
 	MTU                 int                         `json:"mtu" yaml:"mtu"`
 	PublicKey           WgKey                       `json:"publickey" yaml:"publickey"`
 	MacAddress          net.HardwareAddr            `json:"macaddress" yaml:"macaddress"`
@@ -236,8 +245,12 @@ func (h *Host) SetTcpProxy(ctx context.Context) error {
 	return db.FromContext(ctx).Model(&Host{}).
 		Where("id = ?", h.ID).
 		Updates(map[string]interface{}{
-			"tcp_proxy_enabled":     h.TcpProxyEnabled,
-			"tcp_proxy_listen_port": h.TcpProxyListenPort,
+			"tcp_proxy_enabled":          h.TcpProxyEnabled,
+			"tcp_proxy_listen_port":      h.TcpProxyListenPort,
+			"tcp_proxy_tls_mode":         h.TcpProxyTLSMode,
+			"tcp_proxy_listen_addr":      h.TcpProxyListenAddr,
+			"tcp_proxy_public_hostname":  h.TcpProxyPublicHostname,
+			"tcp_proxy_cert_fingerprint": h.TcpProxyCertFingerprint,
 		}).Error
 }
 

--- a/schema/nodes.go
+++ b/schema/nodes.go
@@ -467,7 +467,6 @@ func NormaliseTcpProxyPublicHostname(raw string) (string, error) {
 	for _, pfx := range []string{"wss://", "ws://", "https://", "http://"} {
 		if strings.HasPrefix(lower, pfx) {
 			h = h[len(pfx):]
-			lower = strings.ToLower(h)
 			break
 		}
 	}

--- a/schema/nodes.go
+++ b/schema/nodes.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/gravitl/netmaker/db"
@@ -53,10 +55,12 @@ type Node struct {
 	IsGateway                         bool                                  `json:"is_gateway"`
 	IsAutoRelay                       string                                `json:"is_auto_relay"`
 	IsInternetGateway                 bool                                  `json:"is_internet_gateway"`
-	// TcpProxyEnabled: gateway accepts TCP/TLS framed WG uplinks (control-plane flag; runtime is client-side).
+	// TcpProxyEnabled: gateway accepts TCP/WSS framed WG uplinks (control-plane flag; runtime is client-side).
 	TcpProxyEnabled bool `json:"tcp_proxy_enabled"`
-	// TcpProxyListenPort: TCP listen port when TcpProxyEnabled (default 443 if enabled with port 0).
+	// TcpProxyListenPort: listen port when TcpProxyEnabled (default 443 if enabled with port 0).
 	TcpProxyListenPort int `json:"tcp_proxy_listen_port"`
+	// TcpProxyTLSMode: selfsigned (default) or proxy. Empty means selfsigned.
+	TcpProxyTLSMode string `json:"tcp_proxy_tls_mode"`
 	AdditionalGatewayEndpoints        datatypes.JSONSlice[string]           `json:"additional_gateway_endpoints"`
 	RelayedClients                    datatypes.JSONMap                     `json:"relayed_clients"`
 	RelayedIGWClients                 datatypes.JSONMap                     `json:"relayed_igw_clients"`
@@ -429,6 +433,64 @@ func (n *Node) ResetAutoRelayedPeers(ctx context.Context) error {
 // DefaultTcpProxyListenPort is used when TcpProxyEnabled is set with listen port <= 0.
 const DefaultTcpProxyListenPort = 443
 
+// TcpProxyClientPortProxy is the default client-facing WSS port published when
+// TLS mode is proxy (external termination). Override at runtime with the
+// TCP_PROXY_PUBLIC_PORT server environment variable.
+const TcpProxyClientPortProxy = 443
+
+// TcpProxyTLSMode values (host/node). Empty defaults to selfsigned on clients.
+const (
+	TcpProxyTLSModeSelfSigned = "selfsigned"
+	TcpProxyTLSModeProxy      = "proxy"
+)
+
+// NormaliseTcpProxyTLSMode returns a valid mode; empty → selfsigned.
+func NormaliseTcpProxyTLSMode(mode string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", TcpProxyTLSModeSelfSigned:
+		return TcpProxyTLSModeSelfSigned, nil
+	case TcpProxyTLSModeProxy:
+		return TcpProxyTLSModeProxy, nil
+	default:
+		return "", fmt.Errorf("unsupported uplink TLS mode: %s", mode)
+	}
+}
+
+// NormaliseTcpProxyPublicHostname cleans a public hostname for WSS publish.
+// Strips schemes/paths; rejects values that look like URLs with paths or empty hosts.
+func NormaliseTcpProxyPublicHostname(raw string) (string, error) {
+	h := strings.TrimSpace(raw)
+	if h == "" {
+		return "", nil
+	}
+	lower := strings.ToLower(h)
+	for _, pfx := range []string{"wss://", "ws://", "https://", "http://"} {
+		if strings.HasPrefix(lower, pfx) {
+			h = h[len(pfx):]
+			lower = strings.ToLower(h)
+			break
+		}
+	}
+	if i := strings.IndexAny(h, "/?"); i >= 0 {
+		h = h[:i]
+	}
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return "", fmt.Errorf("invalid tcp_proxy_public_hostname")
+	}
+	// Drop accidental port; public port is published separately.
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		h = host
+	} else if strings.HasPrefix(h, "[") && strings.Contains(h, "]") {
+		// leave bracketed IPv6 literals as-is without port
+	}
+	h = strings.TrimSpace(h)
+	if h == "" || strings.ContainsAny(h, " /\\") {
+		return "", fmt.Errorf("invalid tcp_proxy_public_hostname")
+	}
+	return h, nil
+}
+
 func (n *Node) AssignGateway(ctx context.Context) error {
 	if n.NetworkID == "" {
 		return fmt.Errorf("network_id not set")
@@ -568,6 +630,7 @@ func (n *Node) SetTcpProxy(ctx context.Context) error {
 		Updates(map[string]interface{}{
 			"tcp_proxy_enabled":     n.TcpProxyEnabled,
 			"tcp_proxy_listen_port": n.TcpProxyListenPort,
+			"tcp_proxy_tls_mode":    n.TcpProxyTLSMode,
 		}).Error
 }
 

--- a/schema/tcp_proxy_tls_test.go
+++ b/schema/tcp_proxy_tls_test.go
@@ -1,0 +1,37 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/gravitl/netmaker/schema"
+)
+
+func TestNormaliseTcpProxyTLSMode(t *testing.T) {
+	got, err := schema.NormaliseTcpProxyTLSMode("")
+	if err != nil || got != schema.TcpProxyTLSModeSelfSigned {
+		t.Fatalf("got %q %v", got, err)
+	}
+	got, err = schema.NormaliseTcpProxyTLSMode("proxy")
+	if err != nil || got != schema.TcpProxyTLSModeProxy {
+		t.Fatalf("got %q %v", got, err)
+	}
+	_, err = schema.NormaliseTcpProxyTLSMode("letsencrypt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNormaliseTcpProxyPublicHostname(t *testing.T) {
+	got, err := schema.NormaliseTcpProxyPublicHostname("")
+	if err != nil || got != "" {
+		t.Fatalf("empty: %q %v", got, err)
+	}
+	got, err = schema.NormaliseTcpProxyPublicHostname("wss://gateway.example.com/uplink/v1")
+	if err != nil || got != "gateway.example.com" {
+		t.Fatalf("url: %q %v", got, err)
+	}
+	got, err = schema.NormaliseTcpProxyPublicHostname("gateway.example.com:8443")
+	if err != nil || got != "gateway.example.com" {
+		t.Fatalf("hostport: %q %v", got, err)
+	}
+}

--- a/scripts/netmaker.default.env
+++ b/scripts/netmaker.default.env
@@ -32,6 +32,9 @@ NETCLIENT_AUTO_UPDATE=enabled
 # If changed, need to change port of BACKEND_URL for netmaker-ui.
 API_PORT=8081
 EXPORTER_API_PORT=8085
+# Public WSS port published to clients when gateway TLS mode is external termination (proxy).
+# Backend listen port on the gateway can differ. Default is 443.
+# TCP_PROXY_PUBLIC_PORT=443
 # The "allowed origin" for API requests. Change to restrict where API requests can come from with comma-separated
 # URLs. ex:- https://dashboard.netmaker.domain1.com,https://dashboard.netmaker.domain2.com
 CORS_ALLOWED_ORIGIN=*

--- a/scripts/nm-quick.sh
+++ b/scripts/nm-quick.sh
@@ -165,23 +165,18 @@ setup_netclient() {
 	fi
 }
 
+
+
 # configure_netclient - configures server's netclient as a default host and an ingress gateway
 configure_netclient() {
 	sleep 2
-	# NODE_ID=$(sudo cat /etc/netclient/nodes.json | jq -r .netmaker.id)
-	# if [ "$NODE_ID" = "" ] || [ "$NODE_ID" = "null" ]; then
-	# 	echo "Error obtaining NODE_ID for the new network"
-	# 	exit 1
-	# fi
-	# echo "register complete. New node ID: $NODE_ID"
 	HOST_ID=$(sudo cat /etc/netclient/netclient.json | jq -r .id)
 	if [ "$HOST_ID" = "" ] || [ "$HOST_ID" = "null" ]; then
-		echo "Error obtaining HOST_ID for the new network"
-		exit 1
+		echo "Warning: could not obtain HOST_ID from netclient.json, skipping host/gateway configuration"
+		return
 	fi
-	echo "making host a default"
+	echo "making host a default and enabling TCP proxy"
 	echo "Host ID: $HOST_ID"
-	# set as a default host
 	set +e
 	GET_RESPONSE=$(curl -s -w "\n%{http_code}" -X GET "https://api.${NETMAKER_BASE_DOMAIN}/api/hosts/${HOST_ID}" \
 		-H "Authorization: Bearer ${MASTER_KEY}" \
@@ -189,25 +184,28 @@ configure_netclient() {
 	GET_HTTP_CODE=$(echo "$GET_RESPONSE" | tail -n1)
 	HOST_JSON=$(echo "$GET_RESPONSE" | head -n -1)
 	if [ "$GET_HTTP_CODE" != "200" ]; then
-		echo "Warning: failed to fetch host (HTTP $GET_HTTP_CODE), skipping set default"
+		echo "Warning: failed to fetch host (HTTP $GET_HTTP_CODE), skipping host/gateway configuration"
 	else
-		UPDATED_HOST_JSON=$(echo "$HOST_JSON" | jq '.Response | .isdefault = true')
+		UPDATED_HOST_JSON=$(echo "$HOST_JSON" | jq \
+			--arg host "default-gateway.${NETMAKER_BASE_DOMAIN}" \
+			'.Response
+			| .isdefault = true
+			| .tcp_proxy_enabled = true
+			| .tcp_proxy_listen_port = 6443
+			| .tcp_proxy_tls_mode = "proxy"
+			| .tcp_proxy_public_hostname = $host
+			| .tcp_proxy_cert_fingerprint = ""')
 		PUT_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "https://api.${NETMAKER_BASE_DOMAIN}/api/hosts/${HOST_ID}" \
 			-H "Authorization: Bearer ${MASTER_KEY}" \
 			-H "Content-Type: application/json" \
 			-d "$UPDATED_HOST_JSON")
 		if [ "$PUT_HTTP_CODE" != "200" ]; then
-			echo "Warning: failed to set host as default (HTTP $PUT_HTTP_CODE), skipping"
+			echo "Warning: failed to update default host TCP proxy settings (HTTP $PUT_HTTP_CODE)"
+		else
+			echo "Default host and TCP proxy settings updated"
 		fi
 	fi
 	sleep 5
-	# nmctl node create_remote_access_gateway netmaker $NODE_ID
-	# sleep 2
-	# # set failover
-	# if [ "$INSTALL_TYPE" = "pro" ]; then
-	#     #setup failOver
-	# 	curl --location --request POST "https://api.${NETMAKER_BASE_DOMAIN}/api/v1/node/${NODE_ID}/failover" --header "Authorization: Bearer ${MASTER_KEY}"
-	# fi
 	set -e
 }
 
@@ -1209,11 +1207,11 @@ done
 
 	# 11–12. netclient: skip reinstall/join when reusing an existing netmaker.env
 	if [ "$REUSE_EXISTING_CONFIG" -eq 1 ]; then
-		echo "Skipping netclient setup and host configuration (reusing saved configuration)."
+		echo "Skipping netclient reinstall (reusing saved configuration)."
 	else
 		setup_netclient
-		configure_netclient
 	fi
+	configure_netclient
 
 	# 13. print success message
 	print_success

--- a/servercfg/serverconf.go
+++ b/servercfg/serverconf.go
@@ -164,6 +164,22 @@ func GetAPIPort() string {
 	return apiport
 }
 
+// GetTcpProxyPublicPort returns the client-facing WSS port published for
+// external-termination (tls_mode=proxy) gateways. Defaults to 443.
+// Override with TCP_PROXY_PUBLIC_PORT (1–65535).
+func GetTcpProxyPublicPort() int {
+	defaultPort := 443 // keep in sync with schema.TcpProxyClientPortProxy
+	v := strings.TrimSpace(os.Getenv("TCP_PROXY_PUBLIC_PORT"))
+	if v == "" {
+		return defaultPort
+	}
+	port, err := strconv.Atoi(v)
+	if err != nil || port < 1 || port > 65535 {
+		return defaultPort
+	}
+	return port
+}
+
 // GetCoreDNSAddr - gets the core dns address
 func GetCoreDNSAddr() string {
 	addr, _ := GetPublicIP()

--- a/servercfg/serverconf_test.go
+++ b/servercfg/serverconf_test.go
@@ -27,3 +27,22 @@ func TestValidateDomain(t *testing.T) {
 	})
 
 }
+
+func TestGetTcpProxyPublicPort(t *testing.T) {
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "")
+	if got := GetTcpProxyPublicPort(); got != 443 {
+		t.Fatalf("default: got %d", got)
+	}
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "8443")
+	if got := GetTcpProxyPublicPort(); got != 8443 {
+		t.Fatalf("override: got %d", got)
+	}
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "0")
+	if got := GetTcpProxyPublicPort(); got != 443 {
+		t.Fatalf("invalid 0: got %d", got)
+	}
+	t.Setenv("TCP_PROXY_PUBLIC_PORT", "nope")
+	if got := GetTcpProxyPublicPort(); got != 443 {
+		t.Fatalf("invalid string: got %d", got)
+	}
+}


### PR DESCRIPTION

Add TLS mode, listen addr, optional public hostname, and proxy-mode client port (443 / TCP_PROXY_PUBLIC_PORT) when building tcp_proxy_endpoint.

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
