### PR TITLE
v1.7.0:  speed up /api/nodes on SQLite and harden DB under load

### DIFF
--- a/auth/host_session.go
+++ b/auth/host_session.go
@@ -271,6 +271,7 @@ func joinHostToNetworks(ctx context.Context, key models.EnrollmentKey, host *sch
 			true,
 		)
 		if len(violations) > 0 {
+			logic.EmitNewPostureViolationEvents(ctx, nil, violations, models.PostureCheckDeviceInfo{HostID: host.ID.String()}, schema.NetworkID(network.Name))
 			logger.Log(0, fmt.Sprintf("skipping joining network %s due to violations", network.Name))
 			continue
 		}

--- a/controllers/enrollmentkeys.go
+++ b/controllers/enrollmentkeys.go
@@ -538,6 +538,8 @@ func handleHostRegister(w http.ResponseWriter, r *http.Request) {
 		violations, _ := logic.CheckPostureViolationsForHost(r.Context(), &newHost, keyTags, schema.NetworkID(netI), true)
 		if len(violations) == 0 {
 			joinNetworks = append(joinNetworks, netI)
+		} else {
+			logic.EmitNewPostureViolationEvents(r.Context(), nil, violations, models.PostureCheckDeviceInfo{HostID: newHost.ID.String()}, schema.NetworkID(netI))
 		}
 	}
 	if len(joinNetworks) != len(enrollmentKey.Networks) && len(joinNetworks) == 0 {

--- a/controllers/ext_client.go
+++ b/controllers/ext_client.go
@@ -646,8 +646,10 @@ func createExtClient(w http.ResponseWriter, r *http.Request) {
 	if extclient.DeviceID != "" {
 		// check for violations connecting from desktop app
 		staticNode := models.ConvertToStaticNode(extclient)
-		violations, _ := logic.CheckPostureViolations(r.Context(), logic.GetPostureCheckDeviceInfoByNode(r.Context(), &staticNode), schema.NetworkID(extclient.Network))
+		deviceInfo := logic.GetPostureCheckDeviceInfoByNode(r.Context(), &staticNode)
+		violations, _ := logic.CheckPostureViolations(r.Context(), deviceInfo, schema.NetworkID(extclient.Network))
 		if len(violations) > 0 {
+			logic.EmitNewPostureViolationEvents(r.Context(), nil, violations, deviceInfo, schema.NetworkID(extclient.Network))
 			logic.ReturnErrorResponse(w, r, logic.FormatError(errors.New("posture check violations"), logic.Forbidden))
 			return
 		}
@@ -927,8 +929,10 @@ func updateExtClient(w http.ResponseWriter, r *http.Request) {
 	if newclient.DeviceID != "" && newclient.Enabled {
 		// check for violations connecting from desktop app
 		staticNode := models.ConvertToStaticNode(newclient)
-		violations, _ := logic.CheckPostureViolations(r.Context(), logic.GetPostureCheckDeviceInfoByNode(r.Context(), &staticNode), schema.NetworkID(newclient.Network))
+		deviceInfo := logic.GetPostureCheckDeviceInfoByNode(r.Context(), &staticNode)
+		violations, _ := logic.CheckPostureViolations(r.Context(), deviceInfo, schema.NetworkID(newclient.Network))
 		if len(violations) > 0 {
+			logic.EmitNewPostureViolationEvents(r.Context(), nil, violations, deviceInfo, schema.NetworkID(newclient.Network))
 			logic.ReturnErrorResponse(w, r, logic.FormatError(errors.New("posture check violations"), logic.Forbidden))
 			return
 		}

--- a/controllers/hosts.go
+++ b/controllers/hosts.go
@@ -679,7 +679,10 @@ func hostUpdateFallback(w http.ResponseWriter, r *http.Request) {
 			)
 			for _, _node := range _nodes {
 				node := logic.ConvertSchemaNodeToModelsNode(&_node)
-				node.PostureChecksViolations, node.PostureCheckViolationSeverityLevel = logic.CheckPostureViolations(ctx, logic.GetPostureCheckDeviceInfoByNode(ctx, node), schema.NetworkID(node.Network))
+				deviceInfo := logic.GetPostureCheckDeviceInfoByNode(ctx, node)
+				oldViolations := node.PostureChecksViolations
+				node.PostureChecksViolations, node.PostureCheckViolationSeverityLevel = logic.CheckPostureViolations(ctx, deviceInfo, schema.NetworkID(node.Network))
+				logic.EmitNewPostureViolationEvents(ctx, oldViolations, node.PostureChecksViolations, deviceInfo, schema.NetworkID(node.Network))
 				_node.PostureCheckSeverity = node.PostureCheckViolationSeverityLevel
 				_node.PostureCheckLastEvaluationCycleID = uuid.NewString()
 				_node.PostureCheckLastEvaluatedAt = time.Now().UTC()
@@ -1011,6 +1014,7 @@ func addHostToNetwork(w http.ResponseWriter, r *http.Request) {
 
 	violations, _ := logic.CheckPostureViolationsForHost(r.Context(), host, nil, schema.NetworkID(networkID), true)
 	if len(violations) > 0 {
+		logic.EmitNewPostureViolationEvents(r.Context(), nil, violations, models.PostureCheckDeviceInfo{HostID: host.ID.String()}, schema.NetworkID(networkID))
 		logic.ReturnErrorResponseWithJson(w, r, violations, logic.FormatError(errors.New("posture check violations"), logic.BadReq))
 		return
 	}
@@ -1913,6 +1917,7 @@ func approvePendingHost(w http.ResponseWriter, r *http.Request) {
 
 	violations, _ := logic.CheckPostureViolationsForHost(r.Context(), host, keyTags, schema.NetworkID(network.Name), true)
 	if len(violations) > 0 {
+		logic.EmitNewPostureViolationEvents(r.Context(), nil, violations, models.PostureCheckDeviceInfo{HostID: host.ID.String()}, schema.NetworkID(network.Name))
 		err = fmt.Errorf("failed to approve pending host (%s): posture check violations", id)
 		logger.Log(0, err.Error())
 		logic.ReturnErrorResponse(w, r, logic.FormatError(err, logic.BadReq))
@@ -1981,6 +1986,7 @@ func addDefaultHostToNetworks(ctx context.Context, host *schema.Host) {
 
 		violations, _ := logic.CheckPostureViolationsForHost(ctx, host, make(map[models.TagID]struct{}), schema.NetworkID(network.Name), true)
 		if len(violations) > 0 {
+			logic.EmitNewPostureViolationEvents(ctx, nil, violations, models.PostureCheckDeviceInfo{HostID: host.ID.String()}, schema.NetworkID(network.Name))
 			logger.Log(2, "skipping network", network.Name, "for default host", host.Name, ": posture check violations")
 			continue
 		}

--- a/controllers/server.go
+++ b/controllers/server.go
@@ -117,12 +117,21 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 	// 		isOnTrial = true
 	// 	}
 	// }
-	var isDBConnected bool
+	// With SQLite MaxOpenConns(1), a timed Ping can fail while the DB is healthy
+	// but the single connection is held by check-in flush / peer updates.
+	// Treat the pool as connected unless we get a hard connection error.
+	isDBConnected := false
 	sqldb, err := db.FromContext(r.Context()).DB()
 	if err == nil {
-		ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
-		defer cancel()
-		if sqldb.PingContext(ctx) == nil {
+		stats := sqldb.Stats()
+		if stats.OpenConnections == 0 || stats.InUse == 0 {
+			ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+			defer cancel()
+			if pingErr := sqldb.PingContext(ctx); pingErr == nil {
+				isDBConnected = true
+			}
+		} else {
+			// Connection is in use — DB is up; avoid false negatives under load.
 			isDBConnected = true
 		}
 	}

--- a/db/logger.go
+++ b/db/logger.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"gorm.io/gorm/logger"
+)
+
+// newGormLogger returns a GORM logger.
+//
+// Set SQL_DEBUG=true (or "1" / "info") to log every SQL statement with duration.
+// Set SQL_DEBUG=slow to only log statements slower than SQL_SLOW_MS (default 200ms)
+// plus errors. Default remains Silent.
+func newGormLogger() logger.Interface {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv("SQL_DEBUG")))
+	if mode == "" || mode == "false" || mode == "0" {
+		return logger.Default.LogMode(logger.Silent)
+	}
+
+	slowMs := 200 * time.Millisecond
+	if v := os.Getenv("SQL_SLOW_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			slowMs = time.Duration(n) * time.Millisecond
+		}
+	}
+
+	level := logger.Info
+	if mode == "slow" || mode == "warn" {
+		level = logger.Warn
+	}
+
+	return logger.New(
+		log.New(os.Stdout, "[gorm] ", log.LstdFlags|log.Lmicroseconds),
+		logger.Config{
+			SlowThreshold:             slowMs,
+			LogLevel:                  level,
+			IgnoreRecordNotFoundError: true,
+			Colorful:                  false,
+		},
+	)
+}

--- a/db/logger.go
+++ b/db/logger.go
@@ -21,10 +21,10 @@ func newGormLogger() logger.Interface {
 		return logger.Default.LogMode(logger.Silent)
 	}
 
-	slowMs := 200 * time.Millisecond
+	slowThreshold := 200 * time.Millisecond
 	if v := os.Getenv("SQL_SLOW_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			slowMs = time.Duration(n) * time.Millisecond
+			slowThreshold = time.Duration(n) * time.Millisecond
 		}
 	}
 
@@ -36,7 +36,7 @@ func newGormLogger() logger.Interface {
 	return logger.New(
 		log.New(os.Stdout, "[gorm] ", log.LstdFlags|log.Lmicroseconds),
 		logger.Config{
-			SlowThreshold:             slowMs,
+			SlowThreshold:             slowThreshold,
 			LogLevel:                  level,
 			IgnoreRecordNotFoundError: true,
 			Colorful:                  false,

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gravitl/netmaker/servercfg"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // postgresConnector for initializing and
@@ -32,7 +31,7 @@ func (pg *postgresConnector) connect() (*gorm.DB, error) {
 	)
 
 	gormDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+		Logger: newGormLogger(),
 	})
 	if err != nil {
 		return nil, err

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -6,7 +6,6 @@ import (
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // sqliteConnector for initializing and
@@ -49,9 +48,11 @@ func (s *sqliteConnector) connect() (*gorm.DB, error) {
 		}
 	}
 
-	dsn := dbFilePath + "?_journal_mode=WAL&_busy_timeout=5000"
+	// WAL + immediate lock + longer busy wait reduce lock storms under scale.
+	// Keep MaxOpenConns(1): concurrent writers with go-sqlite3 still deadlock easily.
+	dsn := dbFilePath + "?_journal_mode=WAL&_busy_timeout=30000&_txlock=immediate&_synchronous=NORMAL"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+		Logger: newGormLogger(),
 	})
 	if err != nil {
 		return nil, err

--- a/logic/hosts.go
+++ b/logic/hosts.go
@@ -44,6 +44,11 @@ var CheckPostureViolations = func(ctx context.Context, d models.PostureCheckDevi
 	return []models.Violation{}, schema.SeverityUnknown
 }
 
+// EmitNewPostureViolationEvents records audit events for newly observed posture
+// failures. No-op in community; wired by pro.
+var EmitNewPostureViolationEvents = func(ctx context.Context, oldVi, newVi []models.Violation, d models.PostureCheckDeviceInfo, network schema.NetworkID) {
+}
+
 var CheckPostureViolationsForHost = func(ctx context.Context, host *schema.Host, tags map[models.TagID]struct{}, network schema.NetworkID, skipAutoUpdate bool) ([]models.Violation, schema.Severity) {
 	if host == nil {
 		return []models.Violation{}, schema.SeverityUnknown

--- a/logic/nodes.go
+++ b/logic/nodes.go
@@ -85,6 +85,8 @@ func UpdateNodeCheckin(nodeID string) error {
 
 // FlushNodeCheckins - writes all buffered check-in updates to the DB in one batch.
 // Called periodically (e.g., every 30s) to avoid per-checkin write lock contention.
+// Uses a single transaction so SQLite (MaxOpenConns=1) holds the write lock once
+// instead of once per node, which previously made /api/server/status Ping time out.
 func FlushNodeCheckins() {
 	pendingCheckinsMu.Lock()
 	batch := pendingCheckins
@@ -93,19 +95,36 @@ func FlushNodeCheckins() {
 	if len(batch) == 0 {
 		return
 	}
-	var failed int
-	for id, checkin := range batch {
-		node := &schema.Node{
-			ID:          id,
-			LastCheckIn: checkin,
+
+	requeue := func() {
+		pendingCheckinsMu.Lock()
+		for id, checkin := range batch {
+			if existing, exists := pendingCheckins[id]; !exists || checkin.After(existing) {
+				pendingCheckins[id] = checkin
+			}
 		}
-		err := node.UpdateLastCheckIn(db.WithContext(context.TODO()))
-		if err != nil {
-			failed++
+		pendingCheckinsMu.Unlock()
+	}
+
+	ctx := db.WithContext(context.TODO())
+	tx := db.FromContext(ctx).Begin()
+	if tx.Error != nil {
+		slog.Error("FlushNodeCheckins: failed to begin transaction", "error", tx.Error, "total", len(batch))
+		requeue()
+		return
+	}
+
+	for id, checkin := range batch {
+		if err := tx.Model(&schema.Node{}).Where("id = ?", id).Update("last_check_in", checkin).Error; err != nil {
+			_ = tx.Rollback()
+			slog.Error("FlushNodeCheckins: failed to persist checkins", "error", err, "total", len(batch))
+			requeue()
+			return
 		}
 	}
-	if failed > 0 {
-		slog.Error("FlushNodeCheckins: failed to persist checkins", "failed", failed, "total", len(batch))
+	if err := tx.Commit().Error; err != nil {
+		slog.Error("FlushNodeCheckins: failed to commit checkins", "error", err, "total", len(batch))
+		requeue()
 	}
 }
 
@@ -317,13 +336,62 @@ func GetAllNodes(ctx context.Context) ([]models.Node, error) {
 		return nil, err
 	}
 
-	for _, _node := range _nodes {
-		node := ConvertSchemaNodeToModelsNodeWithContext(ctx, &_node)
+	for i := range _nodes {
+		node := ConvertSchemaNodeToModelsNodeWithContext(ctx, &_nodes[i], SkipViolations())
 		ensureNodeMutex(node)
 		nodes = append(nodes, *node)
 	}
+	attachPostureViolations(ctx, _nodes, nodes)
 
 	return nodes, nil
+}
+
+// attachPostureViolations loads violations for all nodes in one query and
+// assigns each node's current-cycle violations onto the models.Node slice.
+// schemaNodes and modelsNodes must be the same length and aligned by index.
+func attachPostureViolations(ctx context.Context, schemaNodes []schema.Node, modelsNodes []models.Node) {
+	if len(schemaNodes) == 0 || len(schemaNodes) != len(modelsNodes) {
+		return
+	}
+	ids := make([]string, 0, len(schemaNodes))
+	for i := range schemaNodes {
+		if schemaNodes[i].ID != "" && schemaNodes[i].PostureCheckLastEvaluationCycleID != "" {
+			ids = append(ids, schemaNodes[i].ID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	all, err := schema.ListViolationsByNodeIDs(ctx, ids)
+	if err != nil {
+		slog.Warn("failed to batch-load posture violations", "error", err, "nodes", len(ids))
+		return
+	}
+	// nodeID -> cycleID -> violations
+	byNodeCycle := make(map[string]map[string][]models.Violation, len(ids))
+	for _, v := range all {
+		cycles := byNodeCycle[v.NodeID]
+		if cycles == nil {
+			cycles = make(map[string][]models.Violation)
+			byNodeCycle[v.NodeID] = cycles
+		}
+		cycles[v.EvaluationCycleID] = append(cycles[v.EvaluationCycleID], models.Violation{
+			CheckID:   v.CheckID,
+			Name:      v.Name,
+			Attribute: v.Attribute,
+			Message:   v.Message,
+			Severity:  v.Severity,
+		})
+	}
+	for i := range modelsNodes {
+		cycleID := schemaNodes[i].PostureCheckLastEvaluationCycleID
+		if cycleID == "" {
+			continue
+		}
+		if cycles, ok := byNodeCycle[schemaNodes[i].ID]; ok {
+			modelsNodes[i].PostureChecksViolations = cycles[cycleID]
+		}
+	}
 }
 
 func AddStaticNodestoList(ctx context.Context, nodes []models.Node) []models.Node {
@@ -412,55 +480,48 @@ func GetNodesByIDs(ids []string) (map[string]models.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := make(map[string]models.Node, len(_nodes))
+	ctx := db.WithContext(context.TODO())
+	if len(_nodes) > 0 {
+		ctx = scope.WithContext(ctx, scope.TenantScope, _nodes[0].TenantID)
+	}
+	modelsNodes := make([]models.Node, len(_nodes))
 	for i := range _nodes {
-		n := ConvertSchemaNodeToModelsNode(&_nodes[i])
+		n := ConvertSchemaNodeToModelsNodeWithContext(ctx, &_nodes[i], SkipViolations())
 		ensureNodeMutex(n)
-		result[_nodes[i].ID] = *n
+		modelsNodes[i] = *n
+	}
+	attachPostureViolations(ctx, _nodes, modelsNodes)
+
+	result := make(map[string]models.Node, len(modelsNodes))
+	for i := range modelsNodes {
+		result[_nodes[i].ID] = modelsNodes[i]
 	}
 	return result, nil
 }
 
-// GetAllNodesAPI - get all nodes for api usage
+// GetAllNodesAPI - get all nodes for api usage.
+// Location/CountryCode are already filled during schema→models conversion from
+// the preloaded Host; do not re-fetch hosts (N+1 on SQLite).
 func GetAllNodesAPI(nodes []models.Node) []models.ApiNode {
-	apiNodes := []models.ApiNode{}
+	apiNodes := make([]models.ApiNode, 0, len(nodes))
 	for i := range nodes {
-		node := nodes[i]
-		if !node.IsStatic {
-			h := &schema.Host{
-				ID: node.HostID,
-			}
-			err := h.Get(db.WithContext(context.TODO()))
-			if err == nil {
-				node.Location = h.Location
-				node.CountryCode = h.CountryCode
-			}
-		}
-		newApiNode := node.ConvertToAPINode()
-		apiNodes = append(apiNodes, *newApiNode)
+		apiNodes = append(apiNodes, *nodes[i].ConvertToAPINode())
 	}
-	return apiNodes[:]
+	return apiNodes
 }
 
-// GetAllNodesAPI - get all nodes for api usage
+// GetAllNodesAPIWithLocation - get all nodes for api usage with location.
+// Uses values already on the models.Node (from host preload / static node).
 func GetAllNodesAPIWithLocation(nodes []models.Node) []models.ApiNode {
-	apiNodes := []models.ApiNode{}
+	apiNodes := make([]models.ApiNode, 0, len(nodes))
 	for i := range nodes {
-		node := nodes[i]
-		newApiNode := node.ConvertToAPINode()
-		if node.IsStatic {
-			newApiNode.Location = node.StaticNode.Location
-		} else {
-			host := &schema.Host{
-				ID: node.HostID,
-			}
-			_ = host.Get(db.WithContext(context.TODO()))
-			newApiNode.Location = host.Location
+		newApiNode := nodes[i].ConvertToAPINode()
+		if nodes[i].IsStatic {
+			newApiNode.Location = nodes[i].StaticNode.Location
 		}
-
 		apiNodes = append(apiNodes, *newApiNode)
 	}
-	return apiNodes[:]
+	return apiNodes
 }
 
 // GetNodesStatusAPI - gets nodes status
@@ -590,12 +651,30 @@ func ConvertSchemaNodeToApiNode(_node *schema.Node) *models.ApiNode {
 	return ConvertSchemaNodeToModelsNode(_node).ConvertToAPINode()
 }
 
-func ConvertSchemaNodeToModelsNode(_node *schema.Node) *models.Node {
-	ctx := scope.WithContext(db.WithContext(context.TODO()), scope.TenantScope, _node.TenantID)
-	return ConvertSchemaNodeToModelsNodeWithContext(ctx, _node)
+type nodeConvertOpts struct {
+	skipViolations bool
 }
 
-func ConvertSchemaNodeToModelsNodeWithContext(ctx context.Context, _node *schema.Node) *models.Node {
+// NodeConvertOption customizes schema→models conversion.
+type NodeConvertOption func(*nodeConvertOpts)
+
+// SkipViolations skips the per-node posture_check_violations query.
+// Use with attachPostureViolations for batched list loads.
+func SkipViolations() NodeConvertOption {
+	return func(o *nodeConvertOpts) { o.skipViolations = true }
+}
+
+func ConvertSchemaNodeToModelsNode(_node *schema.Node, opts ...NodeConvertOption) *models.Node {
+	ctx := scope.WithContext(db.WithContext(context.TODO()), scope.TenantScope, _node.TenantID)
+	return ConvertSchemaNodeToModelsNodeWithContext(ctx, _node, opts...)
+}
+
+func ConvertSchemaNodeToModelsNodeWithContext(ctx context.Context, _node *schema.Node, opts ...NodeConvertOption) *models.Node {
+	cfg := nodeConvertOpts{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	nodeID, err := uuid.Parse(_node.ID)
 	if err != nil {
 		return &models.Node{}
@@ -675,16 +754,18 @@ func ConvertSchemaNodeToModelsNodeWithContext(ctx context.Context, _node *schema
 	}
 
 	var violations []models.Violation
-	_violations, err := _node.ListViolations(ctx)
-	if err == nil {
-		for _, _violation := range _violations {
-			violations = append(violations, models.Violation{
-				CheckID:   _violation.CheckID,
-				Name:      _violation.Name,
-				Attribute: _violation.Attribute,
-				Message:   _violation.Message,
-				Severity:  _violation.Severity,
-			})
+	if !cfg.skipViolations {
+		_violations, err := _node.ListViolations(ctx)
+		if err == nil {
+			for _, _violation := range _violations {
+				violations = append(violations, models.Violation{
+					CheckID:   _violation.CheckID,
+					Name:      _violation.Name,
+					Attribute: _violation.Attribute,
+					Message:   _violation.Message,
+					Severity:  _violation.Severity,
+				})
+			}
 		}
 	}
 

--- a/logic/nodes.go
+++ b/logic/nodes.go
@@ -328,8 +328,23 @@ func DeleteNodeByID(ctx context.Context, node *models.Node) error {
 	return nil
 }
 
-// GetAllNodes - returns all nodes in the DB
+// GetAllNodes - returns all nodes in the DB.
+// List/API responses use posture severity/cycle fields already on the node row
+// (written by the background posture hook). Full violation details are omitted
+// here — use GetAllNodesWithViolations or single-node convert / the dedicated
+// violations API when the detail array is required.
 func GetAllNodes(ctx context.Context) ([]models.Node, error) {
+	return getAllNodes(ctx, false)
+}
+
+// GetAllNodesWithViolations is like GetAllNodes but attaches current-cycle
+// posture_check_violations in one batch query. Intended for the posture hook
+// (event diffs), not for high-frequency list APIs.
+func GetAllNodesWithViolations(ctx context.Context) ([]models.Node, error) {
+	return getAllNodes(ctx, true)
+}
+
+func getAllNodes(ctx context.Context, withViolations bool) ([]models.Node, error) {
 	var nodes []models.Node
 	_nodes, err := (&schema.Node{}).ListAll(ctx, dbtypes.WithAllPreloads())
 	if err != nil {
@@ -341,7 +356,9 @@ func GetAllNodes(ctx context.Context) ([]models.Node, error) {
 		ensureNodeMutex(node)
 		nodes = append(nodes, *node)
 	}
-	attachPostureViolations(ctx, _nodes, nodes)
+	if withViolations {
+		attachPostureViolations(ctx, _nodes, nodes)
+	}
 
 	return nodes, nil
 }
@@ -349,6 +366,7 @@ func GetAllNodes(ctx context.Context) ([]models.Node, error) {
 // attachPostureViolations loads violations for all nodes in one query and
 // assigns each node's current-cycle violations onto the models.Node slice.
 // schemaNodes and modelsNodes must be the same length and aligned by index.
+// Used by GetAllNodesWithViolations (posture hook), not the high-frequency list API.
 func attachPostureViolations(ctx context.Context, schemaNodes []schema.Node, modelsNodes []models.Node) {
 	if len(schemaNodes) == 0 || len(schemaNodes) != len(modelsNodes) {
 		return
@@ -367,7 +385,6 @@ func attachPostureViolations(ctx context.Context, schemaNodes []schema.Node, mod
 		slog.Warn("failed to batch-load posture violations", "error", err, "nodes", len(ids))
 		return
 	}
-	// nodeID -> cycleID -> violations
 	byNodeCycle := make(map[string]map[string][]models.Violation, len(ids))
 	for _, v := range all {
 		cycles := byNodeCycle[v.NodeID]
@@ -385,11 +402,22 @@ func attachPostureViolations(ctx context.Context, schemaNodes []schema.Node, mod
 	}
 	for i := range modelsNodes {
 		cycleID := schemaNodes[i].PostureCheckLastEvaluationCycleID
-		if cycleID == "" {
+		cycles := byNodeCycle[schemaNodes[i].ID]
+		if cycles == nil {
 			continue
 		}
-		if cycles, ok := byNodeCycle[schemaNodes[i].ID]; ok {
-			modelsNodes[i].PostureChecksViolations = cycles[cycleID]
+		if cycleID != "" {
+			if v, ok := cycles[cycleID]; ok {
+				modelsNodes[i].PostureChecksViolations = v
+				continue
+			}
+		}
+		// Fallback when cycle metadata and rows disagree after a partial upsert.
+		if schemaNodes[i].PostureCheckSeverity != schema.SeverityUnknown {
+			for _, v := range cycles {
+				modelsNodes[i].PostureChecksViolations = v
+				break
+			}
 		}
 	}
 }
@@ -490,7 +518,6 @@ func GetNodesByIDs(ids []string) (map[string]models.Node, error) {
 		ensureNodeMutex(n)
 		modelsNodes[i] = *n
 	}
-	attachPostureViolations(ctx, _nodes, modelsNodes)
 
 	result := make(map[string]models.Node, len(modelsNodes))
 	for i := range modelsNodes {
@@ -659,7 +686,8 @@ type nodeConvertOpts struct {
 type NodeConvertOption func(*nodeConvertOpts)
 
 // SkipViolations skips the per-node posture_check_violations query.
-// Use with attachPostureViolations for batched list loads.
+// Use on list paths: severity/cycle fields on the node row are enough;
+// violation details come from the dedicated violations API or single-node get.
 func SkipViolations() NodeConvertOption {
 	return func(o *nodeConvertOpts) { o.skipViolations = true }
 }

--- a/models/structs.go
+++ b/models/structs.go
@@ -472,6 +472,9 @@ type PostureCheckDeviceInfo struct {
 	UserGroups     map[schema.UserGroupID]struct{}
 	// HostID is the Netmaker host's UUID; used to look up MDM state.
 	HostID string
+	// Username / ClientID identify Active User (extclient) posture subjects.
+	Username string
+	ClientID string
 	// MDMState is the most recent sync snapshot for the configured MDM
 	// provider; nil if MDM is not configured or the host hasn't synced yet.
 	MDMState *schema.DeviceMDMState

--- a/orchestrator/node.go
+++ b/orchestrator/node.go
@@ -155,8 +155,11 @@ func (n *NodeOrchestrator) CreateNode(ctx context.Context, host *schema.Host, ne
 
 	go func(ctx context.Context) {
 		modelsNode := logic.ConvertSchemaNodeToModelsNode(node)
+		deviceInfo := logic.GetPostureCheckDeviceInfoByNode(ctx, modelsNode)
+		oldViolations := modelsNode.PostureChecksViolations
 
-		modelsNode.PostureChecksViolations, modelsNode.PostureCheckViolationSeverityLevel = logic.CheckPostureViolations(ctx, logic.GetPostureCheckDeviceInfoByNode(ctx, modelsNode), schema.NetworkID(node.Network.Name))
+		modelsNode.PostureChecksViolations, modelsNode.PostureCheckViolationSeverityLevel = logic.CheckPostureViolations(ctx, deviceInfo, schema.NetworkID(node.Network.Name))
+		logic.EmitNewPostureViolationEvents(ctx, oldViolations, modelsNode.PostureChecksViolations, deviceInfo, schema.NetworkID(node.Network.Name))
 		node.PostureCheckSeverity = modelsNode.PostureCheckViolationSeverityLevel
 		node.PostureCheckLastEvaluationCycleID = uuid.NewString()
 		node.PostureCheckLastEvaluatedAt = time.Now().UTC()

--- a/pro/controllers/posture_check.go
+++ b/pro/controllers/posture_check.go
@@ -345,24 +345,6 @@ func triggerPostureChecks(w http.ResponseWriter, r *http.Request) {
 		mq.PublishPeerUpdate(ctx, false)
 	}(scope.WithContext(db.WithContext(context.Background()), scope.Level(r.Context()), scope.ID(r.Context())))
 
-	logic.LogEvent(r.Context(), &models.Event{
-		Action:      schema.Sync,
-		TriggeredBy: r.Header.Get("user"),
-		Source: models.Subject{
-			ID:   r.Header.Get("user"),
-			Name: r.Header.Get("user"),
-			Type: schema.UserSub,
-		},
-		Target: models.Subject{
-			ID:   string(schema.AllPostureCheckRsrcID),
-			Name: "all",
-			Type: schema.PostureCheckSub,
-		},
-		Origin: schema.Dashboard,
-		Diff: models.Diff{
-			New: map[string]interface{}{"status": "queued"},
-		},
-	})
 	logic.ReturnSuccessResponseWithJson(w, r, map[string]any{"queued": true}, "posture checks queued")
 }
 

--- a/pro/initialize.go
+++ b/pro/initialize.go
@@ -224,6 +224,7 @@ func InitPro() {
 	logic.ValidateEgressReq = proLogic.ValidateEgressReq
 	logic.CheckPostureViolations = proLogic.CheckPostureViolations
 	logic.CheckPostureViolationsForHost = proLogic.CheckPostureViolationsForHost
+	logic.EmitNewPostureViolationEvents = proLogic.EmitNewPostureViolationEvents
 	logic.GetPostureCheckDeviceInfoByNode = proLogic.GetPostureCheckDeviceInfoByNode
 	logic.SyncHostMDMState = mdmpkg.SyncHostMDMState
 	logic.SyncHostEDRState = edrpkg.SyncHostEDRState

--- a/pro/logic/events.go
+++ b/pro/logic/events.go
@@ -107,7 +107,15 @@ func EventWatcher() {
 			Diff:        diff,
 			TimeStamp:   time.Now().UTC(),
 		}
-		a.Create(db.WithContext(context.TODO()))
+		writeCtx := db.WithContext(context.TODO())
+		if e.TenantID != "" {
+			writeCtx = scope.WithContext(writeCtx, scope.TenantScope, e.TenantID)
+		}
+		if err := a.Create(writeCtx); err != nil {
+			slog.Error("failed to persist audit event",
+				"action", e.Action, "network", e.NetworkID, "tenant", e.TenantID, "error", err)
+			continue
+		}
 
 		_siemMtx.Lock()
 		if !_pushToSiem {

--- a/pro/logic/posture_check.go
+++ b/pro/logic/posture_check.go
@@ -97,14 +97,19 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 		return err
 	}
 
-	// One-time backfill: if this tenant has never logged a posture failure,
-	// treat previous violations as empty so current failures appear in activity.
-	// After the first POSTURE_CHECK_FAILED is written, resume new-only dedupe.
-	backfillPostureFailures := false
-	if has, err := (&schema.Event{}).HasAction(ctx, schema.PostureCheckFailed); err != nil {
-		slog.Warn("failed to check for existing posture failure events", "error", err)
+	// One-time backfill per subject type: devices and users are tracked
+	// separately so device events do not suppress user violation backfill.
+	backfillDeviceFailures := false
+	backfillUserFailures := false
+	if has, err := (&schema.Event{}).HasPostureFailureForSubjectType(ctx, schema.DeviceSub); err != nil {
+		slog.Warn("failed to check for existing device posture failure events", "error", err)
 	} else {
-		backfillPostureFailures = !has
+		backfillDeviceFailures = !has
+	}
+	if has, err := (&schema.Event{}).HasPostureFailureForSubjectType(ctx, schema.UserSub); err != nil {
+		slog.Warn("failed to check for existing user posture failure events", "error", err)
+	} else {
+		backfillUserFailures = !has
 	}
 
 	for _, netI := range nets {
@@ -138,7 +143,7 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 						continue
 					}
 					oldVi := extclient.PostureChecksViolations
-					if backfillPostureFailures {
+					if backfillUserFailures {
 						oldVi = nil
 					}
 					EmitNewPostureViolationEvents(ctx, oldVi, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
@@ -158,7 +163,7 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 					continue
 				}
 				oldVi := nodeI.PostureChecksViolations
-				if backfillPostureFailures {
+				if backfillDeviceFailures {
 					oldVi = nil
 				}
 				EmitNewPostureViolationEvents(ctx, oldVi, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
@@ -496,6 +501,8 @@ func GetPostureCheckDeviceInfoByNode(ctx context.Context, node *models.Node) mod
 			KernelVersion:  node.StaticNode.KernelVersion,
 			Tags:           make(map[models.TagID]struct{}),
 			IsUser:         true,
+			Username:       node.StaticNode.OwnerID,
+			ClientID:       node.StaticNode.ClientID,
 			UserGroups:     make(map[schema.UserGroupID]struct{}),
 		}
 		// get user groups
@@ -973,6 +980,7 @@ func asInt(v interface{}) int {
 // every violation newly present in newVi (any attribute). Dedupes by CheckID
 // against oldVi so ongoing failures do not re-fire; cleared violations are
 // ignored. MDM/EDR events keep their provider-specific enrichment fields.
+// Active User subjects are logged as USER; hosts as DEVICE.
 func EmitNewPostureViolationEvents(ctx context.Context, oldVi, newVi []models.Violation, d models.PostureCheckDeviceInfo, network schema.NetworkID) {
 	if len(newVi) == 0 {
 		return
@@ -983,6 +991,19 @@ func EmitNewPostureViolationEvents(ctx context.Context, oldVi, newVi []models.Vi
 			continue
 		}
 		prev[v.CheckID] = struct{}{}
+	}
+
+	sourceID := d.HostID
+	sourceName := d.HostID
+	sourceType := schema.DeviceSub
+	if d.IsUser {
+		sourceType = schema.UserSub
+		sourceID = d.Username
+		sourceName = d.Username
+		if sourceID == "" {
+			sourceID = d.ClientID
+			sourceName = d.ClientID
+		}
 	}
 
 	var mdmProviderID, edrProviderID string
@@ -1000,6 +1021,11 @@ func EmitNewPostureViolationEvents(ctx context.Context, oldVi, newVi []models.Vi
 			"check":    v.Name,
 			"reason":   v.Message,
 			"severity": v.Severity,
+			"is_user":  d.IsUser,
+		}
+		if d.IsUser {
+			payload["username"] = d.Username
+			payload["client_id"] = d.ClientID
 		}
 		switch v.Attribute {
 		case string(schema.MDMCompliance):
@@ -1021,9 +1047,9 @@ func EmitNewPostureViolationEvents(ctx context.Context, oldVi, newVi []models.Vi
 		logic.LogEvent(ctx, &models.Event{
 			Action: schema.PostureCheckFailed,
 			Source: models.Subject{
-				ID:   d.HostID,
-				Name: d.HostID,
-				Type: schema.DeviceSub,
+				ID:   sourceID,
+				Name: sourceName,
+				Type: sourceType,
 			},
 			TriggeredBy: "system",
 			Target: models.Subject{

--- a/pro/logic/posture_check.go
+++ b/pro/logic/posture_check.go
@@ -92,10 +92,21 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	nodes, err := logic.GetAllNodes(ctx)
+	nodes, err := logic.GetAllNodesWithViolations(ctx)
 	if err != nil {
 		return err
 	}
+
+	// One-time backfill: if this tenant has never logged a posture failure,
+	// treat previous violations as empty so current failures appear in activity.
+	// After the first POSTURE_CHECK_FAILED is written, resume new-only dedupe.
+	backfillPostureFailures := false
+	if has, err := (&schema.Event{}).HasAction(ctx, schema.PostureCheckFailed); err != nil {
+		slog.Warn("failed to check for existing posture failure events", "error", err)
+	} else {
+		backfillPostureFailures = !has
+	}
+
 	for _, netI := range nets {
 		networkNodes := logic.GetNetworkNodesMemory(nodes, netI.Name)
 		if len(networkNodes) == 0 {
@@ -126,22 +137,35 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 					if noChecks && len(extclient.PostureChecksViolations) == 0 {
 						continue
 					}
-					emitNewMDMViolationEvents(ctx, extclient.PostureChecksViolations, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
-					emitNewEDRViolationEvents(ctx, extclient.PostureChecksViolations, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
+					oldVi := extclient.PostureChecksViolations
+					if backfillPostureFailures {
+						oldVi = nil
+					}
+					EmitNewPostureViolationEvents(ctx, oldVi, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
 					extclient.PostureChecksViolations = postureChecksViolations
 					extclient.PostureCheckVolationSeverityLevel = postureCheckVolationSeverityLevel
 					extclient.LastEvaluatedAt = time.Now().UTC()
 					logic.SaveExtClient(ctx, &extclient)
 				}
 			} else {
-				if noChecks && len(nodeI.PostureChecksViolations) == 0 {
+				// When no checks are configured and the node is already clean, skip
+				// a full cycle rewrite — but still purge any orphaned historical
+				// violation rows left by older upserts that only appended.
+				if noChecks &&
+					nodeI.PostureCheckViolationSeverityLevel == schema.SeverityUnknown &&
+					len(nodeI.PostureChecksViolations) == 0 {
+					_ = (&schema.Node{ID: nodeI.ID.String(), TenantID: nodeI.TenantID}).DeleteViolations(ctx)
 					continue
 				}
-				emitNewMDMViolationEvents(ctx, nodeI.PostureChecksViolations, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
-				emitNewEDRViolationEvents(ctx, nodeI.PostureChecksViolations, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
+				oldVi := nodeI.PostureChecksViolations
+				if backfillPostureFailures {
+					oldVi = nil
+				}
+				EmitNewPostureViolationEvents(ctx, oldVi, postureChecksViolations, deviceInfo, schema.NetworkID(netI.Name))
 
 				_node := &schema.Node{
 					ID:                                nodeI.ID.String(),
+					TenantID:                          nodeI.TenantID,
 					PostureCheckSeverity:              postureCheckVolationSeverityLevel,
 					PostureCheckLastEvaluationCycleID: uuid.NewString(),
 					PostureCheckLastEvaluatedAt:       time.Now().UTC(),
@@ -161,7 +185,10 @@ func RunPostureChecksForTenant(ctx context.Context) error {
 						EvaluatedAt:       _node.PostureCheckLastEvaluatedAt,
 					})
 				}
-				_ = _node.UpsertViolations(ctx, _violations)
+				if err := _node.UpsertViolations(ctx, _violations); err != nil {
+					slog.Error("failed to upsert posture check violations",
+						"node_id", _node.ID, "error", err)
+				}
 			}
 		}
 	}
@@ -942,94 +969,54 @@ func asInt(v interface{}) int {
 	return 0
 }
 
-// emitNewMDMViolationEvents emits a posture_check_failed audit event for every
-// MDM compliance violation that is newly present (not in oldVi) in newVi.
-// Old violations don't re-fire; cleared violations are also ignored here.
-func emitNewMDMViolationEvents(ctx context.Context, oldVi, newVi []models.Violation, d models.PostureCheckDeviceInfo, network schema.NetworkID) {
+// EmitNewPostureViolationEvents emits a posture_check_failed audit event for
+// every violation newly present in newVi (any attribute). Dedupes by CheckID
+// against oldVi so ongoing failures do not re-fire; cleared violations are
+// ignored. MDM/EDR events keep their provider-specific enrichment fields.
+func EmitNewPostureViolationEvents(ctx context.Context, oldVi, newVi []models.Violation, d models.PostureCheckDeviceInfo, network schema.NetworkID) {
 	if len(newVi) == 0 {
 		return
 	}
 	prev := make(map[string]struct{}, len(oldVi))
 	for _, v := range oldVi {
-		prev[v.CheckID+"|"+v.Message] = struct{}{}
-	}
-	providerID, _ := mdmpkg.ActiveProviderID(ctx)
-	for _, v := range newVi {
-		if v.Attribute != string(schema.MDMCompliance) {
+		if v.CheckID == "" {
 			continue
 		}
-		if _, ok := prev[v.CheckID+"|"+v.Message]; ok {
-			continue
-		}
-		diff := models.Diff{
-			Old: nil,
-			New: map[string]interface{}{
-				"event":     "posture_check_failed",
-				"type":      string(schema.MDMCompliance),
-				"host_id":   d.HostID,
-				"check_id":  v.CheckID,
-				"check":     v.Name,
-				"reason":    v.Message,
-				"severity":  v.Severity,
-				"provider":  providerID,
-				"enrolled":  mdmStateEnrolled(d.MDMState),
-				"compliant": mdmStateCompliant(d.MDMState),
-			},
-		}
-		logic.LogEvent(ctx, &models.Event{
-			Action: schema.PostureCheckFailed,
-			Source: models.Subject{
-				ID:   d.HostID,
-				Name: d.HostID,
-				Type: schema.DeviceSub,
-			},
-			TriggeredBy: "system",
-			Target: models.Subject{
-				ID:   v.CheckID,
-				Name: v.Name,
-				Type: schema.PostureCheckSub,
-			},
-			NetworkID: network,
-			Origin:    schema.Api,
-			Diff:      diff,
-		})
+		prev[v.CheckID] = struct{}{}
 	}
-}
 
-// emitNewEDRViolationEvents emits a posture_check_failed audit event for every
-// EDR compliance violation that is newly present (not in oldVi) in newVi.
-// Old violations don't re-fire; cleared violations are also ignored here.
-func emitNewEDRViolationEvents(ctx context.Context, oldVi, newVi []models.Violation, d models.PostureCheckDeviceInfo, network schema.NetworkID) {
-	if len(newVi) == 0 {
-		return
-	}
-	prev := make(map[string]struct{}, len(oldVi))
-	for _, v := range oldVi {
-		prev[v.CheckID+"|"+v.Message] = struct{}{}
-	}
-	providerID, _ := edrpkg.ActiveProviderID(ctx)
+	var mdmProviderID, edrProviderID string
 	for _, v := range newVi {
-		if v.Attribute != string(schema.EDRCompliance) {
-			continue
+		if v.CheckID != "" {
+			if _, ok := prev[v.CheckID]; ok {
+				continue
+			}
 		}
-		if _, ok := prev[v.CheckID+"|"+v.Message]; ok {
-			continue
+		payload := map[string]interface{}{
+			"event":    "posture_check_failed",
+			"type":     v.Attribute,
+			"host_id":  d.HostID,
+			"check_id": v.CheckID,
+			"check":    v.Name,
+			"reason":   v.Message,
+			"severity": v.Severity,
 		}
-		diff := models.Diff{
-			Old: nil,
-			New: map[string]interface{}{
-				"event":           "posture_check_failed",
-				"type":            string(schema.EDRCompliance),
-				"host_id":         d.HostID,
-				"check_id":        v.CheckID,
-				"check":           v.Name,
-				"reason":          v.Message,
-				"severity":        v.Severity,
-				"provider":        providerID,
-				"agent_installed": edrStateAgentInstalled(d.EDRState),
-				"agent_healthy":   edrStateAgentHealthy(d.EDRState),
-				"risk_level":      edrStateRiskLevel(d.EDRState),
-			},
+		switch v.Attribute {
+		case string(schema.MDMCompliance):
+			if mdmProviderID == "" {
+				mdmProviderID, _ = mdmpkg.ActiveProviderID(ctx)
+			}
+			payload["provider"] = mdmProviderID
+			payload["enrolled"] = mdmStateEnrolled(d.MDMState)
+			payload["compliant"] = mdmStateCompliant(d.MDMState)
+		case string(schema.EDRCompliance):
+			if edrProviderID == "" {
+				edrProviderID, _ = edrpkg.ActiveProviderID(ctx)
+			}
+			payload["provider"] = edrProviderID
+			payload["agent_installed"] = edrStateAgentInstalled(d.EDRState)
+			payload["agent_healthy"] = edrStateAgentHealthy(d.EDRState)
+			payload["risk_level"] = edrStateRiskLevel(d.EDRState)
 		}
 		logic.LogEvent(ctx, &models.Event{
 			Action: schema.PostureCheckFailed,
@@ -1046,7 +1033,10 @@ func emitNewEDRViolationEvents(ctx context.Context, oldVi, newVi []models.Violat
 			},
 			NetworkID: network,
 			Origin:    schema.Api,
-			Diff:      diff,
+			Diff: models.Diff{
+				Old: nil,
+				New: payload,
+			},
 		})
 	}
 }

--- a/schema/event.go
+++ b/schema/event.go
@@ -203,6 +203,20 @@ func (a *Event) HasAction(ctx context.Context, action Action) (bool, error) {
 	return count > 0, err
 }
 
+// HasPostureFailureForSubjectType reports whether a POSTURE_CHECK_FAILED event
+// exists whose source JSON has the given subject_type (DEVICE or USER).
+func (a *Event) HasPostureFailureForSubjectType(ctx context.Context, subType SubjectType) (bool, error) {
+	query := db.FromContext(ctx).Model(&Event{}).
+		Where("action = ?", PostureCheckFailed).
+		Where("source LIKE ?", fmt.Sprintf(`%%"subject_type":"%s"%%`, subType))
+	if tenantID := scope.ID(ctx); tenantID != "" {
+		query = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", eventsTable), tenantID)(query)
+	}
+	var count int64
+	err := query.Limit(1).Count(&count).Error
+	return count > 0, err
+}
+
 func (a *Event) DeleteAllForTenant(ctx context.Context) error {
 	if tenantID := scope.ID(ctx); tenantID != "" {
 		return db.FromContext(ctx).Where(fmt.Sprintf("%s.tenant_id = ?", eventsTable), tenantID).Delete(&Event{}).Error

--- a/schema/event.go
+++ b/schema/event.go
@@ -191,6 +191,18 @@ func (a *Event) List(ctx context.Context, from, to time.Time) (ats []Event, err 
 	return
 }
 
+// HasAction returns true if at least one event with the given action exists
+// for the current tenant (used for one-time posture-failure audit backfill).
+func (a *Event) HasAction(ctx context.Context, action Action) (bool, error) {
+	query := db.FromContext(ctx).Model(&Event{}).Where("action = ?", action)
+	if tenantID := scope.ID(ctx); tenantID != "" {
+		query = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", eventsTable), tenantID)(query)
+	}
+	var count int64
+	err := query.Limit(1).Count(&count).Error
+	return count > 0, err
+}
+
 func (a *Event) DeleteAllForTenant(ctx context.Context) error {
 	if tenantID := scope.ID(ctx); tenantID != "" {
 		return db.FromContext(ctx).Where(fmt.Sprintf("%s.tenant_id = ?", eventsTable), tenantID).Delete(&Event{}).Error

--- a/schema/nodes.go
+++ b/schema/nodes.go
@@ -218,6 +218,21 @@ func (n *Node) ListViolations(ctx context.Context) ([]PostureCheckViolation, err
 	return violations, err
 }
 
+// ListViolationsByNodeIDs fetches posture violations for many nodes in one query.
+// Callers should filter by each node's PostureCheckLastEvaluationCycleID in memory.
+func ListViolationsByNodeIDs(ctx context.Context, nodeIDs []string) ([]PostureCheckViolation, error) {
+	if len(nodeIDs) == 0 {
+		return nil, nil
+	}
+	var violations []PostureCheckViolation
+	query := db.FromContext(ctx).Model(&PostureCheckViolation{}).Where("node_id IN ?", nodeIDs)
+	if tenantID := scope.ID(ctx); tenantID != "" {
+		query = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", postureCheckViolationsTable), tenantID)(query)
+	}
+	err := query.Find(&violations).Error
+	return violations, err
+}
+
 func (n *Node) DeleteViolations(ctx context.Context) error {
 	query := db.FromContext(ctx).Model(&PostureCheckViolation{}).
 		Where("node_id = ?", n.ID)

--- a/schema/nodes.go
+++ b/schema/nodes.go
@@ -185,41 +185,98 @@ func (n *Node) Count(ctx context.Context, options ...dbtypes.Option) (int, error
 	return int(count), err
 }
 
+// UpsertViolations replaces stored violations for this node with the latest
+// evaluation cycle, then updates severity / cycle metadata on the node row.
+// Inserts the new cycle and updates the node first, then deletes older cycles,
+// so readers never observe a window with severity set and zero violation rows.
 func (n *Node) UpsertViolations(ctx context.Context, violations []PostureCheckViolation) error {
+	txCtx := db.BeginTx(ctx)
+	tx := db.FromContext(txCtx)
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	cycleID := n.PostureCheckLastEvaluationCycleID
+
 	if len(violations) > 0 {
 		for i := range violations {
 			if violations[i].TenantID == "" {
 				violations[i].TenantID = n.TenantID
 			}
+			if violations[i].NodeID == "" {
+				violations[i].NodeID = n.ID
+			}
+			if violations[i].EvaluationCycleID == "" {
+				violations[i].EvaluationCycleID = cycleID
+			}
 		}
-
-		err := db.FromContext(ctx).Model(&PostureCheckViolation{}).Create(&violations).Error
-		if err != nil {
+		if err := tx.Model(&PostureCheckViolation{}).Create(&violations).Error; err != nil {
 			return err
 		}
 	}
 
-	return db.FromContext(ctx).Model(&Node{}).
+	if err := tx.Model(&Node{}).
 		Where("id = ?", n.ID).
-		Update("posture_check_severity", n.PostureCheckSeverity).
-		Update("posture_check_last_evaluation_cycle_id", n.PostureCheckLastEvaluationCycleID).
-		Update("posture_check_last_evaluated_at", n.PostureCheckLastEvaluatedAt).
-		Error
+		Updates(map[string]interface{}{
+			"posture_check_severity":                 n.PostureCheckSeverity,
+			"posture_check_last_evaluation_cycle_id": cycleID,
+			"posture_check_last_evaluated_at":        n.PostureCheckLastEvaluatedAt,
+		}).Error; err != nil {
+		return err
+	}
+
+	del := tx.Model(&PostureCheckViolation{}).Where("node_id = ?", n.ID)
+	if tenantID := scope.ID(ctx); tenantID != "" {
+		del = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", postureCheckViolationsTable), tenantID)(del)
+	}
+	if cycleID != "" {
+		// Keep the cycle we just wrote; drop historical rows.
+		del = del.Where("evaluation_cycle_id <> ?", cycleID)
+	}
+	if err := del.Delete(&PostureCheckViolation{}).Error; err != nil {
+		return err
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func (n *Node) ListViolations(ctx context.Context) ([]PostureCheckViolation, error) {
 	var violations []PostureCheckViolation
-	query := db.FromContext(ctx).Model(&PostureCheckViolation{}).
-		Where("node_id = ? AND evaluation_cycle_id = ?", n.ID, n.PostureCheckLastEvaluationCycleID)
+	query := db.FromContext(ctx).Model(&PostureCheckViolation{}).Where("node_id = ?", n.ID)
 	if tenantID := scope.ID(ctx); tenantID != "" {
 		query = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", postureCheckViolationsTable), tenantID)(query)
 	}
-	err := query.Find(&violations).Error
+
+	if n.PostureCheckLastEvaluationCycleID != "" {
+		err := query.Where("evaluation_cycle_id = ?", n.PostureCheckLastEvaluationCycleID).Find(&violations).Error
+		if err != nil {
+			return nil, err
+		}
+		if len(violations) > 0 || n.PostureCheckSeverity == SeverityUnknown {
+			return violations, nil
+		}
+	}
+
+	// Fallback when severity says violated but the stored cycle has no rows
+	// (partial upsert from older delete-first writers).
+	fallback := db.FromContext(ctx).Model(&PostureCheckViolation{}).Where("node_id = ?", n.ID)
+	if tenantID := scope.ID(ctx); tenantID != "" {
+		fallback = dbtypes.WithFilter(fmt.Sprintf("%s.tenant_id", postureCheckViolationsTable), tenantID)(fallback)
+	}
+	err := fallback.Find(&violations).Error
 	return violations, err
 }
 
 // ListViolationsByNodeIDs fetches posture violations for many nodes in one query.
-// Callers should filter by each node's PostureCheckLastEvaluationCycleID in memory.
+// Prefer after UpsertViolations (which replaces cycles) so only current rows remain.
+// Callers should still filter by each node's PostureCheckLastEvaluationCycleID.
 func ListViolationsByNodeIDs(ctx context.Context, nodeIDs []string) ([]PostureCheckViolation, error) {
 	if len(nodeIDs) == 0 {
 		return nil, nil


### PR DESCRIPTION
Batch posture violation loads and drop redundant host fetches on node list APIs. Also batch check-in flushes, avoid false db_connected flaps when the SQLite pool is busy, tune SQLite DSN, and add optional SQL_DEBUG.

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
