### PR TITLE
v1.7.0: fix: do not auto-assign exit node from ACL access

### DIFF
--- a/logic/acls_selected_ips_test.go
+++ b/logic/acls_selected_ips_test.go
@@ -126,7 +126,7 @@ func TestAppendEgressPolicyRangeExpandsInternet(t *testing.T) {
 	}
 }
 
-func TestApplyInternetExitFromDeviceACL(t *testing.T) {
+func TestAddEgressInfoToPeerByAccess_DoesNotAutoFullTunnelFromInternetACL(t *testing.T) {
 	originalGetEgressByID := getEgressByID
 	t.Cleanup(func() { getEgressByID = originalGetEgressByID })
 
@@ -138,6 +138,13 @@ func TestApplyInternetExitFromDeviceACL(t *testing.T) {
 			Network: "netmaker",
 		},
 	}
+	exitNode := models.Node{
+		CommonNode: models.CommonNode{
+			ID:      exitID,
+			Network: "netmaker",
+			IsGw:    true,
+		},
+	}
 	eli := []schema.Egress{{
 		ID:      "inet-eg",
 		Network: "netmaker",
@@ -146,21 +153,41 @@ func TestApplyInternetExitFromDeviceACL(t *testing.T) {
 		Range:   "*",
 		Nodes:   datatypes.JSONMap{exitID.String(): json.Number("100")},
 	}}
-	acls := []models.Acl{{
-		Enabled: true,
-		Src:     []models.AclPolicyTag{{ID: models.NodeID, Value: clientID.String()}},
-		Dst:     []models.AclPolicyTag{{ID: models.EgressID, Value: "inet-eg"}},
-	}}
 	getEgressByID = func(id string) (schema.Egress, error) {
 		if id == "inet-eg" {
 			return eli[0], nil
 		}
 		return schema.Egress{}, errors.New("not found")
 	}
+	acls := []models.Acl{{
+		Enabled: true,
+		Src:     []models.AclPolicyTag{{ID: models.NodeID, Value: clientID.String()}},
+		Dst:     []models.AclPolicyTag{{ID: models.EgressID, Value: "inet-eg"}},
+	}}
 
-	applyInternetExitFromDeviceACL(&client, eli, acls)
-	if client.InternetGwID != exitID.String() {
-		t.Fatalf("expected InternetGwID %s from internet ACL, got %q", exitID, client.InternetGwID)
+	// ACL grants access to the internet egress, but the client did not select it.
+	AddEgressInfoToPeerByAccess(&client, &exitNode, eli, acls, false)
+	for _, r := range exitNode.EgressDetails.EgressGatewayRanges {
+		if r == IPv4Network || r == IPv6Network {
+			t.Fatalf("ACL access alone must not attach default route %s; got %v", r, exitNode.EgressDetails.EgressGatewayRanges)
+		}
+	}
+	if InternetExitRoutingNodeID(&client) != "" {
+		t.Fatalf("client must not be treated as exit client without selection, got %q", InternetExitRoutingNodeID(&client))
+	}
+
+	// Explicit assignment (legacy InternetGwID) still attaches full-tunnel ranges.
+	client.InternetGwID = exitID.String()
+	exitNode.EgressDetails = models.EgressDetails{}
+	AddEgressInfoToPeerByAccess(&client, &exitNode, eli, acls, false)
+	hasV4 := false
+	for _, r := range exitNode.EgressDetails.EgressGatewayRanges {
+		if r == IPv4Network {
+			hasV4 = true
+		}
+	}
+	if !hasV4 {
+		t.Fatalf("explicit exit assignment should attach 0.0.0.0/0, got %v", exitNode.EgressDetails.EgressGatewayRanges)
 	}
 }
 

--- a/logic/acls_selected_ips_test.go
+++ b/logic/acls_selected_ips_test.go
@@ -191,6 +191,86 @@ func TestAddEgressInfoToPeerByAccess_DoesNotAutoFullTunnelFromInternetACL(t *tes
 	}
 }
 
+func TestSuppressInternetExitIfNoACLAccess(t *testing.T) {
+	originalGetEgressByID := getEgressByID
+	t.Cleanup(func() { getEgressByID = originalGetEgressByID })
+
+	clientID := uuid.New()
+	exitID := uuid.New()
+	eli := []schema.Egress{{
+		ID:      "inet-eg",
+		Network: "netmaker",
+		Status:  true,
+		Type:    schema.EgressTypeInternet,
+		Range:   "*",
+		Nodes:   datatypes.JSONMap{exitID.String(): json.Number("100")},
+	}}
+	getEgressByID = func(id string) (schema.Egress, error) {
+		if id == "inet-eg" {
+			return eli[0], nil
+		}
+		return schema.Egress{}, errors.New("not found")
+	}
+
+	allowACL := []models.Acl{{
+		Enabled: true,
+		Src:     []models.AclPolicyTag{{ID: models.NodeID, Value: clientID.String()}},
+		Dst:     []models.AclPolicyTag{{ID: models.EgressID, Value: "inet-eg"}},
+	}}
+	denyACLs := []models.Acl{{
+		Enabled: true,
+		Src:     []models.AclPolicyTag{{ID: models.NodeID, Value: clientID.String()}},
+		Dst:     []models.AclPolicyTag{{ID: models.NodeTagID, Value: exitID.String()}}, // gateway node only, not egress
+	}}
+
+	// Assigned exit + ACL grants egress access → keep exit.
+	client := models.Node{
+		CommonNode: models.CommonNode{
+			ID:      clientID,
+			Network: "netmaker",
+		},
+		SelectedInternetEgressID: "inet-eg",
+		InternetGwID:             exitID.String(),
+	}
+	SuppressInternetExitIfNoACLAccess(&client, eli, allowACL, false)
+	if client.SelectedInternetEgressID != "inet-eg" || client.InternetGwID != exitID.String() {
+		t.Fatalf("expected exit kept when ACL allows egress, got selection=%q gw=%q",
+			client.SelectedInternetEgressID, client.InternetGwID)
+	}
+
+	// Assigned exit but policy does not include exit egress → suppress for this update.
+	client.SelectedInternetEgressID = "inet-eg"
+	client.InternetGwID = exitID.String()
+	SuppressInternetExitIfNoACLAccess(&client, eli, denyACLs, false)
+	if client.SelectedInternetEgressID != "" || client.InternetGwID != "" {
+		t.Fatalf("expected exit suppressed without egress ACL, got selection=%q gw=%q",
+			client.SelectedInternetEgressID, client.InternetGwID)
+	}
+
+	// Default device policy on → do not suppress even without egress ACL.
+	client.SelectedInternetEgressID = "inet-eg"
+	client.InternetGwID = exitID.String()
+	SuppressInternetExitIfNoACLAccess(&client, eli, denyACLs, true)
+	if client.SelectedInternetEgressID != "inet-eg" || client.InternetGwID != exitID.String() {
+		t.Fatalf("expected exit kept when default policy enabled, got selection=%q gw=%q",
+			client.SelectedInternetEgressID, client.InternetGwID)
+	}
+
+	// Policy includes node with dst all-resources ("*") → keep assigned exit.
+	allResourcesACL := []models.Acl{{
+		Enabled: true,
+		Src:     []models.AclPolicyTag{{ID: models.NodeID, Value: clientID.String()}},
+		Dst:     []models.AclPolicyTag{{ID: models.NodeTagID, Value: "*"}},
+	}}
+	client.SelectedInternetEgressID = "inet-eg"
+	client.InternetGwID = exitID.String()
+	SuppressInternetExitIfNoACLAccess(&client, eli, allResourcesACL, false)
+	if client.SelectedInternetEgressID != "inet-eg" || client.InternetGwID != exitID.String() {
+		t.Fatalf("expected exit kept when policy dst is all-resources, got selection=%q gw=%q",
+			client.SelectedInternetEgressID, client.InternetGwID)
+	}
+}
+
 func TestGetEgressToEgressPoliciesForNode(t *testing.T) {
 	originalGetEgressByID := getEgressByID
 	originalGetEgressByNetwork := getEgressByNetwork

--- a/logic/egress.go
+++ b/logic/egress.go
@@ -399,37 +399,6 @@ func ResolveInternetExitRoutingNode(node *models.Node) {
 	}
 }
 
-// applyInternetExitFromDeviceACL sets InternetGwID in-memory when a device ACL
-// grants this node access to a single internet egress and no exit is selected.
-// That attaches the exit node peer (0.0.0.0/0, default gw) the same way explicit
-// exit selection does. Multiple internet exits still require an explicit choice.
-func applyInternetExitFromDeviceACL(node *models.Node, eli []schema.Egress, acls []models.Acl) {
-	if node == nil || node.SelectedInternetEgressID != "" || node.InternetGwID != "" {
-		return
-	}
-	routingID := ""
-	for i := range eli {
-		e := eli[i]
-		if !e.Status || e.Network != node.Network || !IsEgressInternetGateway(e) {
-			continue
-		}
-		if !DoesNodeHaveAccessToEgress(node, &e, acls) {
-			continue
-		}
-		id := FirstInternetEgressRoutingNodeID(e)
-		if id == "" || id == node.ID.String() {
-			continue
-		}
-		if routingID != "" && routingID != id {
-			return
-		}
-		routingID = id
-	}
-	if routingID != "" {
-		node.InternetGwID = routingID
-	}
-}
-
 // FirstInternetEgressRoutingNodeID returns a routing node ID from an internet egress.
 func FirstInternetEgressRoutingNodeID(e schema.Egress) string {
 	for nodeID := range e.Nodes {
@@ -1116,10 +1085,10 @@ func AddEgressInfoToPeerByAccess(node, targetNode *models.Node, eli []schema.Egr
 		if !e.Status || e.Network != targetNode.Network {
 			continue
 		}
-		if IsEgressInternetGateway(e) && !usesPeerAsInternetExit(node, targetNode) && isDefaultPolicyActive {
-			// Default-allow must not auto-full-tunnel every peer. Explicit exit
-			// selection or a specific ACL (handled below when default is off)
-			// is required to attach 0.0.0.0/0.
+		if IsEgressInternetGateway(e) && !usesPeerAsInternetExit(node, targetNode) {
+			// Never auto-full-tunnel from ACL/gateway access alone. Full-tunnel
+			// (0.0.0.0/0, ::/0) requires explicit exit selection
+			// (SelectedInternetEgressID) or a legacy InternetGwID assignment.
 			continue
 		}
 		if !isDefaultPolicyActive {

--- a/logic/egress.go
+++ b/logic/egress.go
@@ -399,6 +399,62 @@ func ResolveInternetExitRoutingNode(node *models.Node) {
 	}
 }
 
+// assignedInternetEgress returns the active internet egress this node is configured to use
+// (SelectedInternetEgressID, or legacy InternetGwID matched against eli routing nodes).
+func assignedInternetEgress(node *models.Node, eli []schema.Egress) *schema.Egress {
+	if node == nil {
+		return nil
+	}
+	if node.SelectedInternetEgressID != "" {
+		for i := range eli {
+			e := &eli[i]
+			if e.ID == node.SelectedInternetEgressID && e.Status && e.Network == node.Network && IsEgressInternetGateway(*e) {
+				return e
+			}
+		}
+		return nil
+	}
+	if node.InternetGwID == "" {
+		return nil
+	}
+	for i := range eli {
+		e := &eli[i]
+		if !e.Status || e.Network != node.Network || !IsEgressInternetGateway(*e) {
+			continue
+		}
+		if _, ok := e.Nodes[node.InternetGwID]; ok {
+			return e
+		}
+	}
+	return nil
+}
+
+// SuppressInternetExitIfNoACLAccess clears the in-memory exit assignment for this peer
+// update when the node is not allowed to use its assigned internet egress. Sticky DB
+// selection is preserved; full-tunnel and default-gw changes are not applied.
+//
+// Exit is applied when the node is assigned an exit and any of:
+//   - the default device (all-resources) policy is enabled
+//   - an enabled policy that includes this node has dst all-resources ("*")
+//   - an enabled policy that includes this node has the exit egress in dst
+func SuppressInternetExitIfNoACLAccess(node *models.Node, eli []schema.Egress, acls []models.Acl, defaultDevicePolicyEnabled bool) {
+	if node == nil || defaultDevicePolicyEnabled {
+		return
+	}
+	if node.SelectedInternetEgressID == "" && node.InternetGwID == "" {
+		return
+	}
+	e := assignedInternetEgress(node, eli)
+	if e == nil {
+		return
+	}
+	if DoesNodeHaveAccessToEgress(node, e, acls) {
+		return
+	}
+	node.SelectedInternetEgressID = ""
+	node.InternetGwID = ""
+}
+
 // FirstInternetEgressRoutingNodeID returns a routing node ID from an internet egress.
 func FirstInternetEgressRoutingNodeID(e schema.Egress) string {
 	for nodeID := range e.Nodes {

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -326,9 +326,6 @@ func GetPeerUpdateForHost(ctx context.Context, network string, host *schema.Host
 		defaultDevicePolicy, _ := GetDefaultPolicy(ctx, schema.NetworkID(node.Network), models.DevicePolicy)
 		GetNodeEgressInfo(&node, eli, acls)
 		ResolveInternetExitRoutingNode(&node)
-		if !defaultDevicePolicy.Enabled {
-			applyInternetExitFromDeviceACL(&node, eli, acls)
-		}
 		egsWithDomain := ListAllByRoutingNodeWithDomain(eli, node.ID.String())
 		if len(egsWithDomain) > 0 {
 			hostPeerUpdate.EgressWithDomains = append(hostPeerUpdate.EgressWithDomains, egsWithDomain...)

--- a/logic/peers.go
+++ b/logic/peers.go
@@ -326,6 +326,7 @@ func GetPeerUpdateForHost(ctx context.Context, network string, host *schema.Host
 		defaultDevicePolicy, _ := GetDefaultPolicy(ctx, schema.NetworkID(node.Network), models.DevicePolicy)
 		GetNodeEgressInfo(&node, eli, acls)
 		ResolveInternetExitRoutingNode(&node)
+		SuppressInternetExitIfNoACLAccess(&node, eli, acls, defaultDevicePolicy.Enabled)
 		egsWithDomain := ListAllByRoutingNodeWithDomain(eli, node.ID.String())
 		if len(egsWithDomain) > 0 {
 			hostPeerUpdate.EgressWithDomains = append(hostPeerUpdate.EgressWithDomains, egsWithDomain...)


### PR DESCRIPTION
ACL/gateway policies may allow reachability to an internet egress, but full-tunnel (0.0.0.0/0) must only apply when the user explicitly selects an exit node.

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netmaker is awesome.
